### PR TITLE
various error messages including extreme inputs and others

### DIFF
--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -29,7 +29,11 @@ cut.integer <- function(x, breaks, include.lowest = FALSE, right = TRUE, ordered
   assert_choice(breaks_mode, c("default", "pretty", "quantile"))
   assert_class(label_sep, "character")
   assert_choice(balance, c("left", "right"))
-  
+  if(length(x) %in% length(breaks) %in% 1) stop("if x is a scalar, breaks must be given in intervals")
+  if(length(breaks) == 1) {
+    if(2 * breaks > max(x) - min(x) + 1) stop("range too small for the number of breaks specified")
+    if(length(x) <= breaks) warning("breaks is a scalar not smaller than the length of x")
+  }
   # if breaks are not specified (i.e. only the number of breaks is provided)
   if(length(breaks) == 1){
     
@@ -76,6 +80,7 @@ cut.integer <- function(x, breaks, include.lowest = FALSE, right = TRUE, ordered
     include.lowest <- TRUE
     right <- TRUE
   
+    
   # use breakpoints as is if provided  
   } else if(length(breaks > 1)){
     

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -35,6 +35,10 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = FALSE, right 
     if(length(x) <= breaks) warning("breaks is a scalar not smaller than the length of x")
   }
   
+  if(is.unsorted(breaks)){
+    breaks <- sort(breaks)
+    warning(paste("breaks were unsorted and are now sorted in the following order:", paste0(breaks, collapse = " ")))
+  }
   
   # if breaks are not specified (i.e. only the number of breaks is provided)
   if(length(breaks) == 1){

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -28,17 +28,27 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = FALSE, right 
   assert_class(label_sep, "character")
   assert_choice(balance, c("left", "right"))
   
+  # NAs in breaks
+  if(anyNA(breaks)) {
+    breaks <- na.omit(breaks)
+    warning("missing values in breaks were removed")
+  }
+  
+  # unsorted breaks
+  if(is.unsorted(breaks)){
+    breaks <- sort(breaks)
+    warning(paste("breaks were unsorted and are now sorted in the following order:", paste0(breaks, collapse = " ")))
+  }
+
+  # break / x interaction
   if(length(x) %in% length(breaks) %in% 1) stop("if x is a scalar, breaks must be given in intervals")
   
   if(length(breaks) == 1) {
     if(2 * breaks > max(x) - min(x) + 1) stop("range too small for the number of breaks specified")
     if(length(x) <= breaks) warning("breaks is a scalar not smaller than the length of x")
   }
-  
-  if(is.unsorted(breaks)){
-    breaks <- sort(breaks)
-    warning(paste("breaks were unsorted and are now sorted in the following order:", paste0(breaks, collapse = " ")))
-  }
+
+  ############################################### assertive checks completed  ###############################################
   
   # if breaks are not specified (i.e. only the number of breaks is provided)
   if(length(breaks) == 1){

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -3,21 +3,19 @@
 #' cut divides the range of x into intervals and codes the values in x according to the interval they fall into.
 #'
 #' @param x A numeric vector which is to be converted to a factor by cutting.
-#' @param breaks Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
+#' @param breaks Either an integer vector of two or more unique cut points or a single integer (greater than or equal to 2) giving the
 #' number of intervals into which x is to be cut.
-#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using "(a,b]" interval notation.
+#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using "a-b c-d" interval notation.
 #' If labels = FALSE, simple integer codes are returned instead of a factor.
 #' @param include.lowest Logical, indicating if an ‘x[i]’ equal to the lowest (or highest, for right = FALSE) ‘breaks’ value should be
 #' included.
 #' @param right	Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.
-#' @param digit.lab	Integer which is used when labels are not given. It determines the number of digits used in formatting the break
-#' numbers.
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @return A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
 #' @examples Z <- sample(10)
 #' cut(Z, breaks = c(0, 5, 10))
 #' @export
-cut.integer <- function(x, breaks, include.lowest = FALSE, right = TRUE, ordered_result = FALSE,
+cut.integer <- function(x, breaks, labels = NULL, include.lowest = FALSE, right = TRUE, ordered_result = FALSE,
                         breaks_mode = "default", label_sep = "-", balance = "left", ...) {
   
   # check function arguments
@@ -29,11 +27,15 @@ cut.integer <- function(x, breaks, include.lowest = FALSE, right = TRUE, ordered
   assert_choice(breaks_mode, c("default", "pretty", "quantile"))
   assert_class(label_sep, "character")
   assert_choice(balance, c("left", "right"))
+  
   if(length(x) %in% length(breaks) %in% 1) stop("if x is a scalar, breaks must be given in intervals")
+  
   if(length(breaks) == 1) {
     if(2 * breaks > max(x) - min(x) + 1) stop("range too small for the number of breaks specified")
     if(length(x) <= breaks) warning("breaks is a scalar not smaller than the length of x")
   }
+  
+  
   # if breaks are not specified (i.e. only the number of breaks is provided)
   if(length(breaks) == 1){
     
@@ -107,8 +109,20 @@ cut.integer <- function(x, breaks, include.lowest = FALSE, right = TRUE, ordered
   }
   
   # create integer-based interval labels using label_sep
-  recode_labels <- paste(head(breakpoints, -1) + floorInc, tail(breakpoints, -1) - ceilingDec, sep = label_sep)
-  
+  if(is.null(labels)) {
+    recode_labels <- paste(head(breakpoints, -1) + floorInc, tail(breakpoints, -1) - ceilingDec, sep = label_sep)
+  } else if(length(labels) == 1){
+    if(labels == FALSE) {
+    recode_labels <- FALSE
+    }
+  } else if(!is.null(labels)) {
+    if(length(labels) == length(breakpoints) - 1) {
+      recode_labels <- labels
+    } else if(length(labels) != length(breakpoints) -1) {
+      stop("if labels not 'NULL' and not 'F', it must be the same length as the number of brackets resulting from 'breaks'")
+    }
+    
+  }
   cut.default(x, breaks = breakpoints, labels = recode_labels, include.lowest = include.lowest,
               right = right, ordered_result = ordered_result, ...)
   

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -123,7 +123,11 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = FALSE, right 
     }
     
   }
-  cut.default(x, breaks = breakpoints, labels = recode_labels, include.lowest = include.lowest,
+  output <- cut.default(x, breaks = breakpoints, labels = recode_labels, include.lowest = include.lowest,
               right = right, ordered_result = ordered_result, ...)
   
+  if(anyNA(output)) {
+    warning(paste(sum(is.na(output)), "missing values generated"))
+  }
+  output
 }

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -4,15 +4,18 @@
 \alias{cut.integer}
 \title{Convert Numeric to Factor}
 \usage{
-\method{cut}{integer}(x, breaks, include.lowest = FALSE, right = TRUE,
-  ordered_result = FALSE, breaks_mode = "default", label_sep = "-",
-  balance = "left", ...)
+\method{cut}{integer}(x, breaks, labels = NULL, include.lowest = FALSE,
+  right = TRUE, ordered_result = FALSE, breaks_mode = "default",
+  label_sep = "-", balance = "left", ...)
 }
 \arguments{
 \item{x}{A numeric vector which is to be converted to a factor by cutting.}
 
-\item{breaks}{Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
+\item{breaks}{Either an integer vector of two or more unique cut points or a single integer (greater than or equal to 2) giving the
 number of intervals into which x is to be cut.}
+
+\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using "a-b c-d" interval notation.
+If labels = FALSE, simple integer codes are returned instead of a factor.}
 
 \item{include.lowest}{Logical, indicating if an ‘x[i]’ equal to the lowest (or highest, for right = FALSE) ‘breaks’ value should be
 included.}
@@ -20,12 +23,6 @@ included.}
 \item{right}{Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
-
-\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using "(a,b]" interval notation.
-If labels = FALSE, simple integer codes are returned instead of a factor.}
-
-\item{digit.lab}{Integer which is used when labels are not given. It determines the number of digits used in formatting the break
-numbers.}
 }
 \value{
 A factor is returned, unless labels = FALSE which results in an integer vector of level codes.

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -116,6 +116,9 @@ test_that("cut.integer error cases", {
 test_that("cut.integer warning cases", {
   expect_warning(cut(sample(10), breaks = c(0, 4, 5)), 
                  "[[:digit:]]+ missing values generated$")
+  
+  expect_warning(cut(sample(10), breaks = c(10, 0, 3)), 
+                 "^breaks were unsorted and are now sorted in the following order:")
 })
 
 

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -33,6 +33,10 @@ case20 <- cut(int3_norep, breaks = 5, balance = "right")
 # for extremely few values
 case21 <- cut(1L, breaks = c(0, 1, 9), include.lowest = T)
 
+# non-default labels
+case22 <- cut(sample(10), breaks = 3, labels = letters[1:3])
+case23 <- cut(sample(10), breaks = 3, labels = F)
+
 
 test_that("cut.integer returns same as cut.default but with better labels for length(break) > 1", {
   # right = T
@@ -82,6 +86,12 @@ test_that("cut.integer returns expected (natural) intervals with better labels f
 
 })
 
+test_that("cut.integer with user-defined labels", {
+  expect_equal(levels(case22), c("a", "b", "c"))
+  expect_equal(sort(unique(case23)), c(1, 2, 3))
+})
+
+
 # can't be assigned because of error. Created within testthat
 test_that("cut.integer error cases", {
   
@@ -95,9 +105,13 @@ test_that("cut.integer error cases", {
   ## should produce an error if breaks > length(x), since integer bins can't be created if bins should contain at least two integers.
   expect_error(cut(sample(2), breaks = 3), 
                "range too small for the number of breaks specified")
+  expect_error(cut(sample(10), breaks = 3, labels = letters[1:4]), 
+               "if labels not 'NULL' and not 'F', it must be the same length as the number of brackets resulting from 'breaks'")
+  expect_error(cut(sample(10), breaks = 3, labels = letters[1:99]), 
+               "if labels not 'NULL' and not 'F', it must be the same length as the number of brackets resulting from 'breaks'")
 
 })
 
 test_that("cut.integer if breaks outside range(x)", {
-  
+  # not yet finished
 }) 

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -119,6 +119,9 @@ test_that("cut.integer warning cases", {
   
   expect_warning(cut(sample(10), breaks = c(10, 0, 3)), 
                  "^breaks were unsorted and are now sorted in the following order:")
+  
+  expect_warning(cut(sample(10), breaks = c(NA, 0, 10)), 
+                 "missing values in breaks were removed$")
 })
 
 

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -38,6 +38,7 @@ case22 <- cut(sample(10), breaks = 3, labels = letters[1:3])
 case23 <- cut(sample(10), breaks = 3, labels = F)
 
 
+
 test_that("cut.integer returns same as cut.default but with better labels for length(break) > 1", {
   # right = T
   expect_equal(levels(case1), c("2-5", "6-10"))
@@ -111,6 +112,14 @@ test_that("cut.integer error cases", {
                "if labels not 'NULL' and not 'F', it must be the same length as the number of brackets resulting from 'breaks'")
 
 })
+
+test_that("cut.integer warning cases", {
+  expect_warning(cut(sample(10), breaks = c(0, 4, 5)), 
+                 "[[:digit:]]+ missing values generated$")
+})
+
+
+
 
 test_that("cut.integer if breaks outside range(x)", {
   # not yet finished

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -30,6 +30,9 @@ case18 <- cut(int3_norep, breaks = 4, balance = "right")
 case19 <- cut(int3_norep, breaks = 5, balance = "left")
 case20 <- cut(int3_norep, breaks = 5, balance = "right")
 
+# for extremely few values
+case21 <- cut(1L, breaks = c(0, 1, 9), include.lowest = T)
+
 
 test_that("cut.integer returns same as cut.default but with better labels for length(break) > 1", {
   # right = T
@@ -78,3 +81,23 @@ test_that("cut.integer returns expected (natural) intervals with better labels f
   expect_equal(levels(case20), c("1-19", "20-39", "40-59", "60-79", "80-99"))
 
 })
+
+# can't be assigned because of error. Created within testthat
+test_that("cut.integer error cases", {
+  
+  ## should produce an error: length(breaks) == length(x) == 1
+  expect_error(cut(1L, breaks = 2), 
+               "if x is a scalar, breaks must be given in intervals")
+  
+  ## should not produce an error if breaks are already given
+  expect_equal(levels(case21), c("0-1", "2-9"))
+  
+  ## should produce an error if breaks > length(x), since integer bins can't be created if bins should contain at least two integers.
+  expect_error(cut(sample(2), breaks = 3), 
+               "range too small for the number of breaks specified")
+
+})
+
+test_that("cut.integer if breaks outside range(x)", {
+  
+}) 


### PR DESCRIPTION
This pull request closes #3 since it provides input checks and corresponding error messages for general case specified in #3 as well as tests for the two cases. 

In addition, it provides a (preliminary) improvement to the following issues (see commit messages), mainly error handling: 
- the argument `labels` is added for consistency with `cut.default`. This is desirable since if one wants to use `cut` for integers without being interested in standard labels, but because of method dispatch, `cut.integer` is called.
- providing a non-specific warning message saying how many missing values were generated, if any. Could be extended in the way that it is tracked back why that happened (i.e. NAs in `x`, `breaks` disjunct with `x` etc).
- sorting `breaks` if they are not and output warning with the new order.
- removing NAs in `breaks` and issue a warning.
