### PR TITLE
update master from devel to 0.1.0.9001

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
+^README\.Rmd$
+^README-.*\.png$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: refactor
 Type: Package
 Title: Better factor handling for R
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: c(
   person("Lorenz", "Walthert", email = "lorenz.walthert@icloud.com", role = "cre"),
   person("Jon", "Calder", email = "jonmcalder@gmail.com", role = "aut"))

--- a/R/cfactor.R
+++ b/R/cfactor.R
@@ -2,16 +2,23 @@
 #'
 #' A wrapper for \code{factor} with enhanced control.
 #' @inheritParams base::factor
-#' @param sep A character vector giving all strings that are used to separate the lower numerical boundary of a range from the upper 
+#' @param sep A character vector giving all strings that are used to separate 
+#'  the lower numerical boundary of a range from the upper 
 #'  numerical boundary within \code{x}. 
-#' @return An object of class "factor" which has a set of integer codes the length of \code{x} with a "levels" attribute of mode character
-#'  and unique (!anyDuplicated(.)) entries. If argument ordered is true (or ordered() is used) the result has class c("ordered", "factor").
-#' @details \code{cfactor} wraps \code{\link{factor}} but provides enhanced control. \cr
-#'  The order of the levels is determined by sorting the numerical values preceeding the separators indicated in \code{sep}. If 
-#'  \code{sep} is set to \code{NULL} or if not every value of \code{x} contains numbers, the same ordering as in \code{factor} is applied. 
+#' @return An object of class "factor" which has a set of integer codes the 
+#'  length of \code{x} with a "levels" attribute of mode character
+#'  and unique (!anyDuplicated(.)) entries. If argument ordered is true (or 
+#'  ordered() is used) the result has class c("ordered", "factor").
+#' @details \code{cfactor} wraps \code{\link{factor}} but provides enhanced 
+#'  control. \cr
+#'  The order of the levels is determined by sorting the numerical values 
+#'  preceeding the separators indicated in \code{sep}. If 
+#'  \code{sep} is set to \code{NULL} or if not every value of \code{x} contains 
+#'  numbers, the same ordering as in \code{factor} is applied. 
 #' @examples cfactor(c("a", "c", "b", "c", "d"))
 #' @export
-cfactor <- function(x, levels, labels = levels, exclude = NA, ordered = is.ordered(x), nmax = NA, sep = c("-", "to")) {
+cfactor <- function(x, levels, labels = levels, exclude = NA,
+                    ordered = is.ordered(x), nmax = NA, sep = c("-", "to")) {
 
   `%w/o%` <- function(x, y) x[!x %in% y] # opposite of %in%
 
@@ -24,9 +31,10 @@ cfactor <- function(x, levels, labels = levels, exclude = NA, ordered = is.order
       start <- vapply(sep, "[", 1, FUN.VALUE = numeric(1)) # extract start of sep
       start <- ifelse(start == -1, nchar(uniq_x) + 1 , start)
       before <- substr(uniq_x, 1, start - 1)
-      before <- gsub("[[:space:]]", "", before)
       # remove all non-digit characters and return the order of the numbers
-      rmpattern <- paste0("[^[:digit:]\\", options()$OutDec, "]") # get the systems decimal separator
+      before <- gsub("[[:space:]]", "", before)
+      # get the systems decimal separator
+      rmpattern <- paste0("[^[:digit:]\\", options()$OutDec, "]") 
       finalorder <- order(as.numeric(gsub(rmpattern, "", before)))
       
       levels <- uniq_x[finalorder]
@@ -37,7 +45,9 @@ cfactor <- function(x, levels, labels = levels, exclude = NA, ordered = is.order
   }
   
   # create the factor
-  output <- factor(x, levels = levels, labels = labels, exclude = exclude, ordered = ordered, nmax = nmax) # only x should never be looked up in .GlobalEnv
+  ## only x should never be looked up in .GlobalEnv
+  output <- factor(x, levels = levels, labels = labels, exclude = exclude, 
+                   ordered = ordered, nmax = nmax) 
   prior <- as.character(unique(x))
   posterior <- ifelse(levels == labels, levels(output), levels)
   
@@ -45,13 +55,15 @@ cfactor <- function(x, levels, labels = levels, exclude = NA, ordered = is.order
   if(!setequal(prior, posterior)) {
     # levels that are not current names
     if(!all(posterior %in% prior)) {
-      warning(paste("the following levels were empty: \n", paste(c(posterior %w/o% prior), collapse = "\n")),
+      warning(paste("the following levels were empty: \n", 
+                    paste(c(posterior %w/o% prior), collapse = "\n")), 
               call. = F)
     }
 
     # current names that don't become levels
     if(!all(prior %in% posterior)) {
-      warning(paste("the following levels were removed: \n", paste(prior[!(prior %in% posterior)], collapse = "\n")),
+      warning(paste("the following levels were removed: \n", 
+                    paste(prior[!(prior %in% posterior)], collapse = "\n")), 
               call. = F)
     }
   }

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -20,7 +20,6 @@
 #'  \item 'default' will result in intervals spread as evenly as possible over the exact range of x
 #'  \item 'pretty' will generate rounded breakpoints for the intervals (often extending slightly beyond the range of x) based on 
 #'  \link[base]{pretty}
-#'  \item 'quantile' will form the intervals so as to result in similar frequencies of occurrence in each of the intervals
 #' }
 #' @param label_sep A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
 #'  will result in labels like 1-10 11-20 21-30 etc
@@ -44,7 +43,7 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
   assert_class(include.lowest, "logical")
   assert_class(right, "logical")
   assert_class(ordered_result, "logical")
-  assert_choice(breaks_mode, c("default", "pretty", "quantile"))
+  assert_choice(breaks_mode, c("default", "pretty"))
   assert_class(label_sep, "character")
   
   # NAs in breaks
@@ -98,10 +97,6 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
     if(breaks_mode == "pretty"){
       
       breakpoints <- pretty(x, breaks)
-      
-    } else if(breaks_mode == "quantile"){
-      
-      # not yet implemented
       
     } else if(breaks_mode == "default"){
       

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -1,42 +1,47 @@
-#' Convert Numeric to Factor
+#' Create Bins for Numeric vectors
 #' 
-#' cut divides the range of x into intervals and codes the values in x according
+#' cut divides the range of \code{x} into intervals and codes the values in \code{x} according
 #' to the interval they fall into.
 #' 
 #' @param x A numeric vector which is to be converted to a factor by cutting.
 #' @param breaks Either an integer vector of two or more unique cut points or a
 #'   single integer (greater than or equal to 2) giving the number of intervals
-#'   into which x is to be cut.
+#'   into which \code{x} is to be cut.
 #' @param labels Labels for the levels of the resulting category. By default,
-#'   labels are constructed using "a-b c-d" interval notation. If labels =
-#'   FALSE, simple integer codes are returned instead of a factor.
+#'   labels are constructed using "a-b c-d" interval notation. If \code{labels =
+#'   FALSE}, simple integer codes are returned instead of a factor.
 #' @param include.lowest Logical, indicating if an "x[i]" equal to the lowest
-#'   (or highest, for right = FALSE) "breaks" value should be included. Note
-#'   that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE,
+#'   (or highest, for \code{right = FALSE)} "breaks" value should be included. Note
+#'   that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
 #'   since this is more intuitive for integer intervals.
 #' @param right	Logical, indicating how to create the bins. This is utilized in
 #'   two different ways based on the type of breaks argument. In the
-#'   conventional case, where a breaks vector is supplied, right = TRUE
+#'   conventional case, where a breaks vector is supplied, \code{right = TRUE}
 #'   indicates that bins should be closed on the right (and open on the left) or
-#'   vice versa. If a single integer breaks value is provided, then right = TRUE
+#'   vice versa. If a single integer breaks value is provided, then \code{right = TRUE}
 #'   indicates that bins will be determined such that those on the right are
 #'   larger (if it is not possible for all bins to be evenly sized).
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @param breaks_mode A parameter indicating how to determine the intervals when
 #'   breaks is specified as a scalar. \itemize{ \item 'default' will result in
-#'   intervals spread as evenly as possible over the exact range of x \item
+#'   intervals spread as evenly as possible over the exact range of \code{x}. \item
 #'   'pretty' will generate rounded breakpoints for the intervals (often
-#'   extending slightly beyond the range of x) based on \link[base]{pretty} 
-#'   \item 'quantile' will form the intervals so as to result in similar
-#'   frequencies of occurrence in each of the intervals }
+#'   extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}
 #' @param label_sep A single or short character string used to generate labels
 #'   for the intervals e.g. the default value of "-" will result in labels like
-#'   1-10 11-20 21-30 etc
-#' @param ... Further arguments to be passed to \code{\link{cut.default}}.
-#' @return A factor is returned, unless labels = FALSE which results in an
+#'   1-10 11-20 21-30 etc.
+#' @param ... Further arguments to be passed to or from other methods, 
+#'  in particular to \code{\link{cut.default}}.
+#' @details In deviation from \code{cut.default}, \code{cut.integer} does not have
+#'  an argument \code{dig.lab}, but instead has two arguments that do not exist
+#'  for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+#'  Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
+#'   since this is more intuitive for integer intervals.
+#' @return A factor is returned, unless \code{labels = FALSE} which results in an
 #'   integer vector of level codes.
-#' @examples Z <- sample(10)
-#'  cut(Z, breaks = c(0, 5, 10))
+#' @examples random <- sample(10)
+#'  cut(random, breaks = seq(0, 100, by = 10))[1:10]
+
 #' @export
 
 cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right = TRUE, ordered_result = FALSE,

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -6,14 +6,14 @@
 #' @param breaks Either an integer vector of two or more unique cut points or a single integer (greater than or equal to 2) giving the
 #'  number of intervals into which x is to be cut.
 #' @param labels Labels for the levels of the resulting category. By default, labels are constructed using "a-b c-d" interval notation.
-#'  If labels = FALSE, simple integer codes are returned instead of a factor.
-#' @param include.lowest Logical, indicating if an "x[i]" equal to the lowest (or highest, for right = FALSE) "breaks" value should be
-#'  included. Note that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE, since this is more intuitive for integer 
-#'  intervals.
+#'  If \code{labels = FALSE}, simple integer codes are returned instead of a factor.
+#' @param include.lowest Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) \code{breaks} 
+#'  value should be included. Note that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE, since this is more 
+#'  intuitive for integer intervals.
 #' @param right	Logical, indicating how to create the bins. This is utilized in two different ways based on the type of breaks argument. 
-#'  In the conventional case, where a breaks vector is supplied, right = TRUE indicates that bins should be closed on the right (and open 
-#'  on the left) or vice versa. If a single integer breaks value is provided, then right = TRUE indicates that bins will be determined 
-#'  such that those on the right are larger (if it is not possible for all bins to be evenly sized).
+#'  In the conventional case, where a breaks vector is supplied, \code{right = TRUE} indicates that bins should be closed on the right 
+#'  (and open on the left) or vice versa. If a single integer breaks value is provided, then right = TRUE indicates that bins will be 
+#'  determined such that those on the right are larger (if it is not possible for all bins to be evenly sized).
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @param breaks_mode A parameter indicating how to determine the intervals when breaks is specified as 
 #'  a scalar. \itemize{
@@ -23,6 +23,7 @@
 #' }
 #' @param label_sep A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
 #'  will result in labels like 1-10 11-20 21-30 etc
+#' @inheritParams base::cut
 #' @return A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
 #' @examples Z <- sample(10)
 #'  cut(Z, breaks = c(0, 5, 10))

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -8,43 +8,51 @@
 #'   single integer (greater than or equal to 2) giving the number of intervals
 #'   into which \code{x} is to be cut.
 #' @param labels Labels for the levels of the resulting category. By default,
-#'   labels are constructed using "a-b c-d" interval notation. If \code{labels =
-#'   FALSE}, simple integer codes are returned instead of a factor.
+#'   labels are constructed using "a-b c-d" interval notation. If 
+#'   \code{labels = FALSE}, simple integer codes are returned instead of a 
+#'   factor.
 #' @param include.lowest Logical, indicating if an "x[i]" equal to the lowest
-#'   (or highest, for \code{right = FALSE)} "breaks" value should be included. Note
-#'   that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
-#'   since this is more intuitive for integer intervals.
+#'   (or highest, for \code{right = FALSE)} "breaks" value should be included. 
+#'   Note that unlike \code{\link[base]{cut.default}}, here 
+#'   \code{include.lowest} defaults to \code{TRUE}, since this is more 
+#'   intuitive for integer intervals.
 #' @param right	Logical, indicating how to create the bins. This is utilized in
 #'   two different ways based on the type of breaks argument. In the
 #'   conventional case, where a breaks vector is supplied, \code{right = TRUE}
 #'   indicates that bins should be closed on the right (and open on the left) or
-#'   vice versa. If a single integer breaks value is provided, then \code{right = TRUE}
-#'   indicates that bins will be determined such that those on the right are
-#'   larger (if it is not possible for all bins to be evenly sized).
+#'   vice versa. If a single integer breaks value is provided, then 
+#'   \code{right = TRUE} indicates that bins will be determined such that those 
+#'   on the right are larger (if it is not possible for all bins to be evenly 
+#'   sized).
 #' @param ordered_result Logical: should the result be an ordered factor?
-#' @param breaks_mode A parameter indicating how to determine the intervals when
-#'   breaks is specified as a scalar. \itemize{ \item 'default' will result in
-#'   intervals spread as evenly as possible over the exact range of \code{x}. \item
-#'   'pretty' will generate rounded breakpoints for the intervals (often
-#'   extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}
+#' @param breaks_mode A parameter indicating how to determine the intervals 
+#'  when breaks is specified as a scalar. 
+#'  \itemize{ 
+#'    \item 'default' will result in intervals spread as evenly as possible 
+#'    over the exact range of \code{x}. 
+#'    \item 'pretty' will generate rounded breakpoints for the intervals (often
+#'    extending slightly beyond the range of \code{x}) based on 
+#'    \link[base]{pretty}.}
 #' @param label_sep A single or short character string used to generate labels
 #'   for the intervals e.g. the default value of "-" will result in labels like
 #'   1-10 11-20 21-30 etc.
 #' @param ... Further arguments to be passed to or from other methods, 
 #'  in particular to \code{\link{cut.default}}.
-#' @details In deviation from \code{cut.default}, \code{cut.integer} does not have
-#'  an argument \code{dig.lab}, but instead has two arguments that do not exist
-#'  for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
-#'  Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
-#'   since this is more intuitive for integer intervals.
-#' @return A factor is returned, unless \code{labels = FALSE} which results in an
-#'   integer vector of level codes.
+#' @details In deviation from \code{cut.default}, \code{cut.integer} does not 
+#'  have an argument \code{dig.lab}, but instead has two arguments that do not 
+#'  exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+#'  Note that unlike \code{\link[base]{cut.default}}, here 
+#'  \code{include.lowest} defaults to \code{TRUE}, since this is more intuitive 
+#'  for integer intervals.
+#' @return A factor is returned, unless \code{labels = FALSE} which results in 
+#' an integer vector of level codes.
 #' @examples random <- sample(10)
 #'  cut(random, breaks = seq(0, 100, by = 10))[1:10]
 
 #' @export
 
-cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right = TRUE, ordered_result = FALSE,
+cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, 
+                        right = TRUE, ordered_result = FALSE,
                         breaks_mode = "default", label_sep = "-", ...) {
   
   # check function arguments
@@ -72,8 +80,10 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
   new_breaks <- floor(breaks)
   if(!setequal(new_breaks, breaks)){
     differ <- new_breaks != breaks
-    warning(paste("When coerced to integers, the following breaks were truncated (rounded down): \n ", 
-          paste(paste(breaks[differ], "to", new_breaks[differ]), " \n ", collapse = " ")))
+    warning(paste("When coerced to integers, the following breaks were", 
+                  "truncated (rounded down): \n ", 
+            paste(paste(breaks[differ], "to", new_breaks[differ]), " \n ", 
+                  collapse = " ")))
           
     breaks <- new_breaks
   }
@@ -81,23 +91,31 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
   # unsorted breaks
   if(is.unsorted(breaks)){
     breaks <- sort(breaks)
-    warning(paste("breaks were unsorted and are now sorted in the following order:", paste0(breaks, collapse = " ")))
+    warning(paste(
+      "breaks were unsorted and are now sorted in the following order:", 
+      paste0(breaks, collapse = " ")))
   }
   
   # breaks that create bins of width 1
   n_of_1bins <- diff(breaks)[-1] == 1
   if(sum(n_of_1bins > 0)) {
-    warning(paste("this break specification produces", 
-                  sum(n_of_1bins), "bin(s) of width 1. The corresponding label(s) are:", 
-                  paste(breaks[c(F, F, n_of_1bins)], collapse = ", "))) # + 2 to get right index because of (1) diff and (2) first diff dropped
+    warning(paste("this break specification produces", sum(n_of_1bins), 
+                  "bin(s) of width 1. The corresponding label(s) are:", 
+                  paste(breaks[c(F, F, n_of_1bins)], collapse = ", "))) 
   }
 
   # break / x interaction
-  if(length(x) == 1 & length(breaks) == 1) stop("if x is a scalar, breaks must be given in intervals")
+  if(length(x) == 1 & length(breaks) == 1) {
+    stop("if x is a scalar, breaks must be given in intervals")
+  }
   
   if(length(breaks) == 1) {
-    if(2 * breaks > max(x) - min(x) + 1) stop("range too small for the number of breaks specified")
-    if(length(x) <= breaks) warning("breaks is a scalar not smaller than the length of x")
+    if(2 * breaks > max(x) - min(x) + 1) {
+      stop("range too small for the number of breaks specified")
+    }
+    if(length(x) <= breaks) {
+      warning("breaks is a scalar not smaller than the length of x")
+    }
   }
 
   ############################################### assertive checks completed  ###############################################
@@ -107,7 +125,8 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
     
     numLabels <- breaks
     
-    # should the breaks be "pretty"? (‘round’ values which cover the range of the values in x)
+    # should the breaks be "pretty"? (‘round’ values which cover the range of 
+    # the values in x)
     # or based on quantiles?
     # or evenly spaced over the range of the data? ("default")
     if(breaks_mode == "pretty"){
@@ -171,8 +190,11 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
   
   # create integer-based interval labels using label_sep
   if(is.null(labels)) {
-    recode_labels <- paste(head(breakpoints, -1) + floorInc, tail(breakpoints, -1) - ceilingDec, sep = label_sep) 
-    # correct labels with binwidth 1, that is where to elements separated by label_sep are the same, i.e. the label "10-10"
+    recode_labels <- paste(head(breakpoints, -1) + floorInc, 
+                           tail(breakpoints, -1) - ceilingDec, 
+                           sep = label_sep) 
+    # correct labels with binwidth 1, that is where to elements separated by 
+    # label_sep are the same, i.e. the label "10-10"
     same <- head(breakpoints, -1) + floorInc == tail(breakpoints, -1) - ceilingDec
     recode_labels[same] <- (tail(breakpoints, -1) - ceilingDec)[same]
     
@@ -184,16 +206,19 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
         if(labels == F) {
           recode_labels <- labels
         } else if(labels != F) {
-          stop("if labels not 'NULL' and not 'F', it must be the same length as the number of bins resulting from 'breaks'")
+          stop(paste("if labels not 'NULL' and not 'F', it must be the same", 
+                     "length as the number of bins resulting from 'breaks'"))
         }
       } else if(length(labels) != 1) {
-        stop("if labels not 'NULL' and not 'F', it must be the same length as the number of bins resulting from 'breaks'")
+        stop(paste("if labels not 'NULL' and not 'F', it must be the same", 
+                   "length as the number of bins resulting from 'breaks'"))
       }
       
     }
   }
-  output <- cut.default(x, breaks = breakpoints, labels = recode_labels, include.lowest = include.lowest,
-              right = right, ordered_result = ordered_result, ...)
+  output <- cut.default(x, breaks = breakpoints, labels = recode_labels, 
+                        include.lowest = include.lowest, right = right, 
+                        ordered_result = ordered_result, ...)
   
   if(anyNA(output)) {
     warning(paste(sum(is.na(output)), "missing values generated"))

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -1,30 +1,40 @@
 #' Convert Numeric to Factor
-#'
-#' cut divides the range of x into intervals and codes the values in x according to the interval they fall into.
-#'
+#' 
+#' cut divides the range of x into intervals and codes the values in x according
+#' to the interval they fall into.
+#' 
 #' @param x A numeric vector which is to be converted to a factor by cutting.
-#' @param breaks Either an integer vector of two or more unique cut points or a single integer (greater than or equal to 2) giving the
-#'  number of intervals into which x is to be cut.
-#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using "a-b c-d" interval notation.
-#'  If labels = FALSE, simple integer codes are returned instead of a factor.
-#' @param include.lowest Logical, indicating if an "x[i]" equal to the lowest (or highest, for right = FALSE) "breaks" value should be
-#'  included. Note that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE, since this is more intuitive for integer 
-#'  intervals.
-#' @param right	Logical, indicating how to create the bins. This is utilized in two different ways based on the type of breaks argument. 
-#'  In the conventional case, where a breaks vector is supplied, right = TRUE indicates that bins should be closed on the right (and open 
-#'  on the left) or vice versa. If a single integer breaks value is provided, then right = TRUE indicates that bins will be determined 
-#'  such that those on the right are larger (if it is not possible for all bins to be evenly sized).
+#' @param breaks Either an integer vector of two or more unique cut points or a
+#'   single integer (greater than or equal to 2) giving the number of intervals
+#'   into which x is to be cut.
+#' @param labels Labels for the levels of the resulting category. By default,
+#'   labels are constructed using "a-b c-d" interval notation. If labels =
+#'   FALSE, simple integer codes are returned instead of a factor.
+#' @param include.lowest Logical, indicating if an "x[i]" equal to the lowest
+#'   (or highest, for right = FALSE) "breaks" value should be included. Note
+#'   that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE,
+#'   since this is more intuitive for integer intervals.
+#' @param right	Logical, indicating how to create the bins. This is utilized in
+#'   two different ways based on the type of breaks argument. In the
+#'   conventional case, where a breaks vector is supplied, right = TRUE
+#'   indicates that bins should be closed on the right (and open on the left) or
+#'   vice versa. If a single integer breaks value is provided, then right = TRUE
+#'   indicates that bins will be determined such that those on the right are
+#'   larger (if it is not possible for all bins to be evenly sized).
 #' @param ordered_result Logical: should the result be an ordered factor?
-#' @param breaks_mode A parameter indicating how to determine the intervals when breaks is specified as 
-#'  a scalar. \itemize{
-#'  \item 'default' will result in intervals spread as evenly as possible over the exact range of x
-#'  \item 'pretty' will generate rounded breakpoints for the intervals (often extending slightly beyond the range of x) based on 
-#'  \link[base]{pretty}
-#'  \item 'quantile' will form the intervals so as to result in similar frequencies of occurrence in each of the intervals
-#' }
-#' @param label_sep A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
-#'  will result in labels like 1-10 11-20 21-30 etc
-#' @return A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
+#' @param breaks_mode A parameter indicating how to determine the intervals when
+#'   breaks is specified as a scalar. \itemize{ \item 'default' will result in
+#'   intervals spread as evenly as possible over the exact range of x \item
+#'   'pretty' will generate rounded breakpoints for the intervals (often
+#'   extending slightly beyond the range of x) based on \link[base]{pretty} 
+#'   \item 'quantile' will form the intervals so as to result in similar
+#'   frequencies of occurrence in each of the intervals }
+#' @param label_sep A single or short character string used to generate labels
+#'   for the intervals e.g. the default value of "-" will result in labels like
+#'   1-10 11-20 21-30 etc
+#' @param ... Further arguments to be passed to \code{\link{cut.default}}.
+#' @return A factor is returned, unless labels = FALSE which results in an
+#'   integer vector of level codes.
 #' @examples Z <- sample(10)
 #'  cut(Z, breaks = c(0, 5, 10))
 #' @export

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -53,10 +53,10 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE, right =
   }
   
   # corece breaks to integers
-  new_breaks <- round(breaks)
+  new_breaks <- floor(breaks)
   if(!setequal(new_breaks, breaks)){
     differ <- new_breaks != breaks
-    warning(paste("When coerced to integers, the following breaks were rounded: \n ", 
+    warning(paste("When coerced to integers, the following breaks were truncated (rounded down): \n ", 
           paste(paste(breaks[differ], "to", new_breaks[differ]), " \n ", collapse = " ")))
           
     breaks <- new_breaks

--- a/R/cut.ordered.R
+++ b/R/cut.ordered.R
@@ -1,31 +1,44 @@
 #' Create Bins for ordered Factors
 #'
-#' cut divides the range of \code{x} into intervals and codes the values in \code{x} according to the interval they fall into.
+#' cut divides the range of \code{x} into intervals and codes the values in 
+#'  \code{x} according to the interval they fall into.
 #'
 #' @param x A numeric vector which is to be converted to a factor by cutting.
-#' @param breaks Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
+#' @param breaks Either a numeric vector of two or more unique cut points or a 
+#'  single number (greater than or equal to 2) giving the
 #' number of intervals into which \code{x} is to be cut.
-#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using \code{a-b, c-d} interval notation.
-#' If \code{labels = FALSE}, simple integer codes are returned instead of a factor.
-#' @param include.lowest Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) breaks value 
-#' should be included.
-#' @param right	Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.
+#' @param labels Labels for the levels of the resulting category. By default, 
+#'  labels are constructed using \code{a-b, c-d} interval notation.
+#'  If \code{labels = FALSE}, simple integer codes are returned instead of a 
+#'  factor.
+#' @param include.lowest Logical, indicating if an \code{x[i]} equal to the 
+#'  lowest (or highest, for \code{right = FALSE}) breaks value should be 
+#'  included.
+#' @param right	Logical, indicating if the intervals should be closed on the 
+#'  right (and open on the left) or vice versa.
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @param breaks_mode A parameter indicating how to determine the intervals when
-#'   breaks is specified as a scalar. \itemize{ \item 'default' will result in
-#'   intervals spread as evenly as possible over the exact range of \code{x}. \item
+#'   breaks is specified as a scalar. 
+#'   \itemize{ 
+#'    \item 'default' will result in
+#'    intervals spread as evenly as possible over the exact range of \code{x}. 
+#'    \item
 #'   'pretty' will generate rounded breakpoints for the intervals (often
-#'   extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}
-#' @param label_sep A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
-#'  will result in labels like a-c d-g i-z etc.
+#'   extending slightly beyond the range of \code{x}) based on 
+#'   \link[base]{pretty}.}
+#' @param label_sep A single or short character string used to generate labels 
+#'  for the intervals e.g. the default value of "-" will result in labels like 
+#'  a-c d-g i-z etc.
 #' @param ... Further arguments to be passed to or from other methods, 
 #'  in particular to \code{\link{cut.default}}.
-#' @details In deviation from \code{cut.default}, \code{cut.ordered} does not have
-#'  an argument \code{dig.lab}, but instead has two arguments that do not exist
-#'  for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
-#'  Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
-#'   since this is more intuitive for integer intervals.
-#' @return A factor is returned, unless \code{labels = FALSE} which results in an integer vector of level codes.
+#' @details In deviation from \code{cut.default}, \code{cut.ordered} does not 
+#'  have an argument \code{dig.lab}, but instead has two arguments that do not 
+#'  exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+#'  Note that unlike \code{\link[base]{cut.default}}, here 
+#'  \code{include.lowest} defaults to \code{TRUE}, since this is more intuitive 
+#'  for integer intervals.
+#' @return A factor is returned, unless \code{labels = FALSE} which results in 
+#'  an integer vector of level codes.
 #' @examples 
 #'  some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
 #'  head(cut(some_letters, breaks = c("a", "q", "z"), 
@@ -34,12 +47,14 @@
 #'  
 #' @export
 cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
-                        right = TRUE, ordered_result = FALSE, breaks_mode = "default", label_sep = "-", ...) {
+                        right = TRUE, ordered_result = FALSE, 
+                        breaks_mode = "default", label_sep = "-", ...) {
   xnum <- as.numeric(x)
   x_lev <- levels(x)
   breakpos <- match(breaks, x_lev)
   if(anyNA(breakpos)){
-    stop(paste("specified breakpoints inexistent in data: \n", paste(breaks[is.na(breakpos)], collapse = "\n")))
+    stop(paste("specified breakpoints inexistent in data: \n", 
+               paste(breaks[is.na(breakpos)], collapse = "\n")))
   }
   
   ######## 
@@ -48,7 +63,8 @@ cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
     
     numLabels <- breaks
     
-    # should the breaks be "pretty"? (‘floor’ values which cover the range of the values in x_num)
+    # should the breaks be "pretty"? 
+    # (‘floor’ values which cover the range of the values in x_num)
     # or evenly spaced over the range of the data? ("default")
     if(breaks_mode == "default"){
       
@@ -61,7 +77,7 @@ cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
         breakpoints[1] <- min(x_num)
       } else if(rem != 0) {
         if(right == FALSE){
-          breakpoints <- rev(seq(from=max(x_num), by = -avg_bin_width, length.out = num))
+          breakpoints <- rev(seq(from=max(x_num), by = - avg_bin_width, length.out = num))
           breakpoints[1] <- min(x_num)
           for(i in 1:rem){
             breakpoints[i+1] <- min(x_num)-1+avg_bin_width*i+i
@@ -107,9 +123,12 @@ cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
   
   # create integer-based interval labels using label_sep
   if(is.null(labels)) {
-    recode_labels <- paste(x_lev[head(breakpos, -1) + floorInc], x_lev[tail(breakpos, -1) - ceilingDec], sep = label_sep) 
+    recode_labels <- paste(x_lev[head(breakpos, -1) + floorInc], 
+                           x_lev[tail(breakpos, -1) - ceilingDec], 
+                           sep = label_sep) 
     
-    # correct labels with binwidth 1, that is where to elements separated by label_sep are the same, i.e. the label "10-10"
+    # correct labels with binwidth 1, that is where to elements separated by 
+    # label_sep are the same, i.e. the label "10-10"
     # deactivated
     same <- head(breakpos, -1) + floorInc == tail(breakpos, -1) - ceilingDec
     # recode_labels[same] <- (tail(breakpos, -1) - ceilingDec)[same] 
@@ -122,16 +141,19 @@ cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
         if(labels == F) {
           recode_labels <- labels
         } else if(labels != F) {
-          stop("if labels not 'NULL' and not 'F', it must be the same length as the number of bins resulting from 'breaks'")
+          stop(paste("if labels not 'NULL' and not 'F', it must be the same", 
+                     "length as the number of bins resulting from 'breaks'"))
         }
       } else if(length(labels) != 1) {
-        stop("if labels not 'NULL' and not 'F', it must be the same length as the number of bins resulting from 'breaks'")
+        stop(paste("if labels not 'NULL' and not 'F', it must be the same", 
+                   "length as the number of bins resulting from 'breaks'"))
       }
       
     }
   }
-  output <- cut.default(xnum, breaks = breakpos, labels = recode_labels, include.lowest = include.lowest,
-                        right = right, ordered_result = ordered_result, ...)
+  output <- cut.default(xnum, breaks = breakpos, labels = recode_labels, 
+                        include.lowest = include.lowest, right = right, 
+                        ordered_result = ordered_result, ...)
   
   
   if(anyNA(output)) {

--- a/R/cut.ordered.R
+++ b/R/cut.ordered.R
@@ -22,7 +22,9 @@ cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
   xnum <- as.numeric(x)
   x_lev <- levels(x)
   breakpos <- match(breaks, x_lev)
-  
+  if(anyNA(breakpos)){
+    stop(paste("specified breakpoints inexistent in data: \n", paste(breaks[is.na(breakpos)], collapse = "\n")))
+  }
   
   ######## 
   # if breaks are not specified (i.e. only the number of breaks is provided)

--- a/R/cut.ordered.R
+++ b/R/cut.ordered.R
@@ -10,16 +10,16 @@
 #' @param include.lowest Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) breaks value 
 #' should be included.
 #' @param right	Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.
-#' @param digit.lab	Integer which is used when labels are not given. It determines the number of digits used in formatting the break
-#' numbers.
 #' @param ordered_result Logical: should the result be an ordered factor?
-#' @inheritParams base::cut
+#' @param breaks_mode Either pretty or default.
+#' @param label_sep A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
+#'  will result in labels like a-c d-g i-z etc#.
 #' @return A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
 #' @examples Z <- stats::rnorm(10000)
 #' cut(Z, breaks = -6:6)
 #' @export
 cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
-                        right = TRUE, digit.lab = 3, ordered_result = FALSE, breaks_mode = "default", label_sep = "-", ...) {
+                        right = TRUE, ordered_result = FALSE, breaks_mode = "default", label_sep = "-", ...) {
   xnum <- as.numeric(x)
   x_lev <- levels(x)
   breakpos <- match(breaks, x_lev)
@@ -33,14 +33,9 @@ cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
     
     numLabels <- breaks
     
-    # should the breaks be "pretty"? (‘round’ values which cover the range of the values in x_num)
-    # or based on quantiles?
+    # should the breaks be "pretty"? (‘floor’ values which cover the range of the values in x_num)
     # or evenly spaced over the range of the data? ("default")
-    if(breaks_mode == "quantile"){
-      
-      # not yet implemented
-      
-    } else if(breaks_mode == "default"){
+    if(breaks_mode == "default"){
       
       range <- max(x_num)-min(x_num)+1
       avg_bin_width <- floor(range/breaks)

--- a/R/cut.ordered.R
+++ b/R/cut.ordered.R
@@ -1,22 +1,35 @@
-#' Convert Numeric to Factor
+#' Create Bins for ordered Factors
 #'
-#' cut divides the range of x into intervals and codes the values in x according to the interval they fall into.
+#' cut divides the range of \code{x} into intervals and codes the values in \code{x} according to the interval they fall into.
 #'
 #' @param x A numeric vector which is to be converted to a factor by cutting.
 #' @param breaks Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
-#' number of intervals into which x is to be cut.
-#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using \code{(a,b]} interval notation.
+#' number of intervals into which \code{x} is to be cut.
+#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using \code{a-b, c-d} interval notation.
 #' If \code{labels = FALSE}, simple integer codes are returned instead of a factor.
 #' @param include.lowest Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) breaks value 
 #' should be included.
 #' @param right	Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.
 #' @param ordered_result Logical: should the result be an ordered factor?
-#' @param breaks_mode Either pretty or default.
+#' @param breaks_mode A parameter indicating how to determine the intervals when
+#'   breaks is specified as a scalar. \itemize{ \item 'default' will result in
+#'   intervals spread as evenly as possible over the exact range of \code{x}. \item
+#'   'pretty' will generate rounded breakpoints for the intervals (often
+#'   extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}
 #' @param label_sep A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
-#'  will result in labels like a-c d-g i-z etc#.
-#' @return A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
-#' @examples Z <- stats::rnorm(10000)
-#' cut(Z, breaks = -6:6)
+#'  will result in labels like a-c d-g i-z etc.
+#' @param ... Further arguments to be passed to or from other methods, 
+#'  in particular to \code{\link{cut.default}}.
+#' @details In deviation from \code{cut.default}, \code{cut.ordered} does not have
+#'  an argument \code{dig.lab}, but instead has two arguments that do not exist
+#'  for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+#'  Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
+#'   since this is more intuitive for integer intervals.
+#' @return A factor is returned, unless \code{labels = FALSE} which results in an integer vector of level codes.
+#' @examples 
+#'  some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
+#'  cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE)
+#'  
 #' @export
 cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,
                         right = TRUE, ordered_result = FALSE, breaks_mode = "default", label_sep = "-", ...) {

--- a/R/cut.ordered.R
+++ b/R/cut.ordered.R
@@ -5,14 +5,15 @@
 #' @param x A numeric vector which is to be converted to a factor by cutting.
 #' @param breaks Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
 #' number of intervals into which x is to be cut.
-#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using "(a,b]" interval notation.
-#' If labels = FALSE, simple integer codes are returned instead of a factor.
-#' @param include.lowest Logical, indicating if an ‘x[i]’ equal to the lowest (or highest, for right = FALSE) ‘breaks’ value should be
-#' included.
+#' @param labels Labels for the levels of the resulting category. By default, labels are constructed using \code{(a,b]} interval notation.
+#' If \code{labels = FALSE}, simple integer codes are returned instead of a factor.
+#' @param include.lowest Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) breaks value 
+#' should be included.
 #' @param right	Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.
 #' @param digit.lab	Integer which is used when labels are not given. It determines the number of digits used in formatting the break
 #' numbers.
 #' @param ordered_result Logical: should the result be an ordered factor?
+#' @inheritParams base::cut
 #' @return A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
 #' @examples Z <- stats::rnorm(10000)
 #' cut(Z, breaks = -6:6)

--- a/R/cut.ordered.R
+++ b/R/cut.ordered.R
@@ -28,7 +28,9 @@
 #' @return A factor is returned, unless \code{labels = FALSE} which results in an integer vector of level codes.
 #' @examples 
 #'  some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
-#'  cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE)
+#'  head(cut(some_letters, breaks = c("a", "q", "z"), 
+#'           labels = c("beginning of the alphabet", "the rest of the alphabeth"), 
+#'           right = TRUE, include.lowest = TRUE))
 #'  
 #' @export
 cut.ordered <- function(x, breaks, labels = NULL, include.lowest = FALSE,

--- a/R/index_cfactor.R
+++ b/R/index_cfactor.R
@@ -1,45 +1,67 @@
-#' index_cfactor
+#' Decode numerical into categorical data
 #'
-#' Decode numerical data into (ordered) factors given the encoding
+#' Decode numerical columns in a data frame into (ordered) factors given the encoding in another data frame.
 #'
-#' @param data A data frame containing integers to decode.
-#' @param index A data frame containing the encoding for \code{data}.
+#' @param data A data frame containing at least one integer column to decode.
+#' @param index A data frame containing the names of the variable to encode, the encoding for \code{data} and labels to assign.
 #' @param variable The name of the column in \code{index} that indicates the variable.
 #' @param encoding The name of the column in \code{index} that indicates the encoding.
-#' @param label The name of the column in \code{index} that indicates the label to be assigned.
 #' @param ... Further arguments to pass to \code{\link{cfactor}}. 
+#' @details Arguments passed via \code{...} to \code{cfactor} are recycled, but only if they can be recycled in full length. Otherwise, an error is thrown. 
+#'  All arguments passed via \code{...} are applied in the order of the data columns but columns not to convert are skipped (see example).
+#'  
+#' @return The original data frame is returned whereas the variables for which an encoding was provided are turned into (ordered) factors. All other columns are returned unmodified.
 #' @examples 
-#' data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
+#'  data <- data.frame(var1 = as.character(sample(x = 1:10, size = 20, replace = TRUE)),
 #'                    var2 = rep(1:2, 20),
 #'                    var3 = sample(20),
 #'                    var4 = 2, 
 #'                    var5 = sample(row.names(USArrests), size = 20),
 #'                    stringsAsFactors = FALSE)
 #' 
-#' index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
+#'  index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
 #'                    encoding = c(1:10, 1:2, 1:20),
 #'                    label = c(letters[1:10], c("male", "female"), LETTERS[1:20]))
 #'                    
-#' index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, TRUE, FALSE))
+#'  index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, TRUE, FALSE))
 #' @export
 
 index_cfactor <- function(data, index, variable = "variable", encoding = "encoding", label = "label", ...){
   
+  
   further_args <- list(...)
   pos_enc <- match(encoding, names(index))
   pos_lab <- match(label, names(index))
+
+  # only apply index to variables in index 
+  var_in_index <- unique(as.character(index[[variable]]))
+  pos_fact <- which(names(data) %in% var_in_index) # find variable from the data that exist in the index
   
-  # only apply index to variables in index
-  pos_fact <- which(names(data) %in% unique(as.character(index[[variable]])))
-  
-  sp_index <- split(index, index[[variable]]) # create three separate indices
+  used_from_index <- var_in_index %in% names(data) # find the variables from the index that exist in the data. Assume all
+  if(!all(used_from_index)) { # if some do not match
+    warning(paste("The following variables from 'index' are not found in 'data': \n", 
+               paste(var_in_index[!used_from_index], sep = "", collapse = " \n ")))
+  }
+  index <- subset(index, get(variable) %in% var_in_index[used_from_index])
+  sp_index <- split(index, index[[variable]], drop = T) # create separate indices
   sp_index_enc <- lapply(sp_index, "[[", pos_enc) # extract the encoding columns
   sp_index_lab <- lapply(sp_index, "[[", pos_lab) # extract the label columns
   
+  # check whether argument can be recycled fully, otherwise stop
   lapply(seq_along(further_args), function(i) if(!is.null(further_args[[i]]) && length(sp_index_enc) %% length(further_args[[i]])){
     stop(paste0("argument '", names(further_args)[[i]], "' is not recycled fully. Number of columns to be decoded should match the length of '", names(further_args)[[i]],"' or mulitiple thereof."))
   })
-    
+  
+  # check whether all variables in pos_fact have numeric counterparts in data, otherwise stop
+  ## get variables of interest
+  rel_var <- names(data)[pos_fact]
+  ## run test for those
+  integer <- vapply(data[rel_var], inherits, what = c("numeric", "integer"), FUN.VALUE = logical(1))
+  if(!all(integer)){
+    stop(paste("The following columns in 'data' cannot be decoded since they do not inherit from class numeric or integer: \n", 
+               paste(names(integer[!integer]), sep = "", collapse = " \n ")))
+  }
+
   data[, pos_fact] <- as.data.frame(Map(cfactor, data[, pos_fact], sp_index_enc, sp_index_lab, ...)) # apply cfactor to the original data, each column with its 
   data
 }

--- a/R/index_cfactor.R
+++ b/R/index_cfactor.R
@@ -48,8 +48,8 @@ index_cfactor <- function(data, index, variable = "variable", encoding = "encodi
   sp_index_lab <- lapply(sp_index, "[[", pos_lab) # extract the label columns
   
   # check whether argument can be recycled fully, otherwise stop
-  lapply(seq_along(further_args), function(i) if(!is.null(further_args[[i]]) && length(sp_index_enc) %% length(further_args[[i]])){
-    stop(paste0("argument '", names(further_args)[[i]], "' is not recycled fully. Number of columns to be decoded should match the length of '", names(further_args)[[i]],"' or mulitiple thereof."))
+  lapply(seq_along(further_args), function(i) if(!is.null(further_args[[i]]) && !(length(further_args[[i]]) %in% c(1, length(sp_index_enc)))){
+    stop(paste0("argument '", names(further_args)[[i]], " has unexpected length. Only arguments of length 1 are recycled. Hence, the arguement should either be of length ", length(sp_index_enc), " or 1"))
   })
   
   # check whether all variables in pos_fact have numeric counterparts in data, otherwise stop

--- a/R/index_cfactor.R
+++ b/R/index_cfactor.R
@@ -7,7 +7,7 @@
 #' @param variable The name of the column in \code{index} that indicates the variable.
 #' @param encoding The name of the column in \code{index} that indicates the encoding.
 #' @param ... Further arguments to pass to \code{\link{cfactor}}. 
-#' @details Arguments passed via \code{...} to \code{cfactor} are recycled, but only if they can be recycled in full length. Otherwise, an error is thrown. 
+#' @details Arguments passed via \code{...} to \code{cfactor} are only recycled if of length 1. Otherwise, an error is thrown. 
 #'  All arguments passed via \code{...} are applied in the order of the data columns but columns not to convert are skipped (see example).
 #'  
 #' @return The original data frame is returned whereas the variables for which an encoding was provided are turned into (ordered) factors. All other columns are returned unmodified.

--- a/R/index_cfactor.R
+++ b/R/index_cfactor.R
@@ -2,10 +2,11 @@
 #'
 #' Decode numerical data into (ordered) factors given the encoding
 #'
-#' @param data A data.frame containing integers to decode.
-#' @param index A data.frame containing the encoding for \code{data}.
+#' @param data A data frame containing integers to decode.
+#' @param index A data frame containing the encoding for \code{data}.
 #' @param variable The name of the column in \code{index} that indicates the variable.
 #' @param encoding The name of the column in \code{index} that indicates the encoding.
+#' @param label The name of the column in \code{index} that indicates the label to be assigned.
 #' @param ... Further arguments to pass to \code{\link{cfactor}}. 
 #' @examples 
 #' data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),

--- a/R/index_cfactor.R
+++ b/R/index_cfactor.R
@@ -1,18 +1,27 @@
 #' Decode numerical into categorical data
 #'
-#' Decode numerical columns in a data frame into (ordered) factors given the encoding in another data frame.
+#' Decode numerical columns in a data frame into (ordered) factors given the 
+#'  encoding in another data frame.
 #'
 #' @param data A data frame containing at least one integer column to decode.
-#' @param index A data frame containing the names of the variable to encode, the encoding for \code{data} and labels to assign.
-#' @param variable The name of the column in \code{index} that indicates the variable.
-#' @param encoding The name of the column in \code{index} that indicates the encoding.
-#' @param label The name of the column in \code{index} that indicates the label that will be given.
+#' @param index A data frame containing the names of the variable to encode, 
+#'  the encoding for \code{data} and labels to assign.
+#' @param variable The name of the column in \code{index} that indicates the 
+#'  variable.
+#' @param encoding The name of the column in \code{index} that indicates the 
+#'  encoding.
+#' @param label The name of the column in \code{index} that indicates the label 
+#'  that will be given.
 #' @param ... Further arguments to be passed to or from other methods, 
 #'  in particular to \code{\link{cfactor}}.
-#' @details Arguments passed via \code{...} to \code{cfactor} are only recycled if of length 1. Otherwise, an error is thrown. 
-#'  All arguments passed via \code{...} are applied in the order of the data columns but columns not to convert are skipped (see example).
+#' @details Arguments passed via \code{...} to \code{cfactor} are only recycled 
+#'  if of length 1. Otherwise, an error is thrown. 
+#'  All arguments passed via \code{...} are applied in the order of the data 
+#'  columns but columns not to convert are skipped (see example).
 #'  
-#' @return The original data frame is returned whereas the variables for which an encoding was provided are turned into (ordered) factors. All other columns are returned unmodified.
+#' @return The original data frame is returned whereas the variables for which 
+#'  an encoding was provided are turned into (ordered) factors. All other 
+#'  columns are returned unmodified.
 #' @examples 
 #'  data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
 #'                    var2 = rep(1:2, 20),
@@ -28,7 +37,8 @@
 #'  index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, TRUE, FALSE))
 #' @export
 
-index_cfactor <- function(data, index, variable = "variable", encoding = "encoding", label = "label", ...){
+index_cfactor <- function(data, index, variable = "variable", 
+                          encoding = "encoding", label = "label", ...){
   
   
   further_args <- list(...)
@@ -37,9 +47,11 @@ index_cfactor <- function(data, index, variable = "variable", encoding = "encodi
 
   # only apply index to variables in index 
   var_in_index <- unique(as.character(index[[variable]]))
-  pos_fact <- which(names(data) %in% var_in_index) # find variable from the data that exist in the index
+  # find variable from the data that exist in the index
+  pos_fact <- which(names(data) %in% var_in_index) 
   
-  used_from_index <- var_in_index %in% names(data) # find the variables from the index that exist in the data. Assume all
+  # find the variables from the index that exist in the data. Assume all
+  used_from_index <- var_in_index %in% names(data) 
   if(!all(used_from_index)) { # if some do not match
     warning(paste("The following variables from 'index' are not found in 'data': \n", 
                paste(var_in_index[!used_from_index], sep = "", collapse = " \n ")))
@@ -50,20 +62,32 @@ index_cfactor <- function(data, index, variable = "variable", encoding = "encodi
   sp_index_lab <- lapply(sp_index, "[[", pos_lab) # extract the label columns
   
   # check whether argument can be recycled fully, otherwise stop
-  lapply(seq_along(further_args), function(i) if(!is.null(further_args[[i]]) && !(length(further_args[[i]]) %in% c(1, length(sp_index_enc)))){
-    stop(paste0("argument '", names(further_args)[[i]], " has unexpected length. Only arguments of length 1 are recycled. Hence, the arguement should either be of length ", length(sp_index_enc), " or 1"))
+  lapply(seq_along(further_args), 
+         function(i) 
+           if(!is.null(further_args[[i]]) && 
+              !(length(further_args[[i]]) %in% c(1, length(sp_index_enc)))){
+             stop(paste0("argument '", names(further_args)[[i]], 
+                "' has unexpected length. Only arguments of length 1 are ",
+                "recycled. Hence, the arguement should either be of length ", 
+                length(sp_index_enc), " or 1"))
   })
   
-  # check whether all variables in pos_fact have numeric counterparts in data, otherwise stop
+  # check whether all variables in pos_fact have numeric counterparts in data, 
+  # otherwise stop
   ## get variables of interest
   rel_var <- names(data)[pos_fact]
   ## run test for those
-  integer <- vapply(data[rel_var], inherits, what = c("numeric", "integer"), FUN.VALUE = logical(1))
+  integer <- vapply(data[rel_var], inherits, what = c("numeric", "integer"), 
+                    FUN.VALUE = logical(1))
+  
   if(!all(integer)){
-    stop(paste("The following columns in 'data' cannot be decoded since they do not inherit from class numeric or integer: \n", 
+    stop(paste("The following columns in 'data' cannot be decoded since they", 
+               "do not inherit from class numeric or integer: \n", 
                paste(names(integer[!integer]), sep = "", collapse = " \n ")))
   }
-
-  data[, pos_fact] <- as.data.frame(Map(cfactor, data[, pos_fact], sp_index_enc, sp_index_lab, ...)) # apply cfactor to the original data, each column with its 
+  
+  # apply cfactor to the original data, each column with its specification
+  data[, pos_fact] <- as.data.frame(Map(cfactor, data[, pos_fact], 
+                                        sp_index_enc, sp_index_lab, ...)) 
   data
 }

--- a/R/index_cfactor.R
+++ b/R/index_cfactor.R
@@ -12,7 +12,7 @@
 #'  
 #' @return The original data frame is returned whereas the variables for which an encoding was provided are turned into (ordered) factors. All other columns are returned unmodified.
 #' @examples 
-#'  data <- data.frame(var1 = as.character(sample(x = 1:10, size = 20, replace = TRUE)),
+#'  data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
 #'                    var2 = rep(1:2, 20),
 #'                    var3 = sample(20),
 #'                    var4 = 2, 

--- a/R/index_cfactor.R
+++ b/R/index_cfactor.R
@@ -6,7 +6,9 @@
 #' @param index A data frame containing the names of the variable to encode, the encoding for \code{data} and labels to assign.
 #' @param variable The name of the column in \code{index} that indicates the variable.
 #' @param encoding The name of the column in \code{index} that indicates the encoding.
-#' @param ... Further arguments to pass to \code{\link{cfactor}}. 
+#' @param label The name of the column in \code{index} that indicates the label that will be given.
+#' @param ... Further arguments to be passed to or from other methods, 
+#'  in particular to \code{\link{cfactor}}.
 #' @details Arguments passed via \code{...} to \code{cfactor} are only recycled if of length 1. Otherwise, an error is thrown. 
 #'  All arguments passed via \code{...} are applied in the order of the data columns but columns not to convert are skipped (see example).
 #'  

--- a/R/refactor.R
+++ b/R/refactor.R
@@ -1,9 +1,15 @@
-#' refactor: Better factor handling for R
+#' Better factor handling for R
 #'
-#' refactor aims to provide better handling of factors by addressing some of the known problems and 
+#' @description \pkg{refactor} aims to provide better handling of factors by addressing some of the known problems and 
 #' short-comings with the existing toolset for working with factors in R.
 #'
+#' @author Lorenz Walthert \email{lorenz.walthert@@icloud.com}, \cr
+#'  Jon Calder \email{jonmcalder@@gmail.com} \cr \cr
+#'  Maintainer: Lorenz Walthert \email{lorenz.walthert@@icloud.com}
+#'  
+#' @seealso 
+#' See \code{vignette("refactor", package = "refactor")} for an overview of the package.
 #' @docType package
 #' @name refactor
 #' @import checkmate
-NULL
+"_PACKAGE"

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,58 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, echo = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "README-"
+)
+```
+
+# refactor
+[![Build Status](https://travis-ci.org/jonmcalder/refactor.svg?branch=master)](https://travis-ci.org/jonmcalder/refactor)
+[![codecov](https://codecov.io/gh/jonmcalder/refactor/branch/master/graph/badge.svg)](https://codecov.io/gh/jonmcalder/refactor)
+
+
+>refactor is an R package which hopes to provide better handling of factors by attempting to address some of the known problems and short-comings present in R   
+>(e.g. as outlined in this [Win-Vector blog post](http://www.win-vector.com/blog/2014/09/factors-are-not-first-class-citizens-in-r/))
+
+## Installation
+
+refactor is not available on CRAN but you can easily install the latest version from github using `devtools`:
+
+```R
+# install.packages("devtools")
+devtools::install_github("jonmcalder/refactor")
+```
+
+## Overview
+
+Below are some of the highlights.  
+
+
+#### Better factor creation:  
+  
+- sequences in strings are detected and used to order the factor levels automatically
+    - e.g. EUR11-20, EUR51-EUR60, EUR101-EUR110  
+    
+- get warnings whenever provided factor levels don't fully match those present in the data  
+
+
+#### Extension of the generic `cut` method to handle (discrete) integer data:  
+  
+- generate 'natural' intervals for factors when using cut on integer vectors 
+    - e.g. `[1,3], [4,6], [7,9]` as opposed to `(0.5, 3.5], (3.5, 6.5], (6.5, 9.5]`  
+    
+- label factor levels more intuitively 
+    - e.g. `1-3, 4-6, 7-9` as opposed to `[1,3], [4,6], [7,9], or (0,3], (3,6], (6-9]`  
+    
+
+## Contributions
+
+Suggestions and feedback are most welcome.  
+  
+Feel free to [open an issue](https://github.com/jonmcalder/refactor/issues) if you want to request a feature or report a bug, and make a pull request if you can contribute.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,44 @@
-# refactor
-[![Build Status](https://travis-ci.org/jonmcalder/refactor.svg?branch=master)](https://travis-ci.org/jonmcalder/refactor)
-[![codecov](https://codecov.io/gh/jonmcalder/refactor/branch/master/graph/badge.svg)](https://codecov.io/gh/jonmcalder/refactor)
 
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+refactor
+========
 
->refactor is an R package which hopes to provide better handling of factors by attempting to address some of the known problems and short-comings present in R   
->(e.g. as outlined in this [Win-Vector blog post](http://www.win-vector.com/blog/2014/09/factors-are-not-first-class-citizens-in-r/))
+[![Build Status](https://travis-ci.org/jonmcalder/refactor.svg?branch=master)](https://travis-ci.org/jonmcalder/refactor) [![codecov](https://codecov.io/gh/jonmcalder/refactor/branch/master/graph/badge.svg)](https://codecov.io/gh/jonmcalder/refactor)
 
-## Installation
+> refactor is an R package which hopes to provide better handling of factors by attempting to address some of the known problems and short-comings present in R
+> (e.g. as outlined in this [Win-Vector blog post](http://www.win-vector.com/blog/2014/09/factors-are-not-first-class-citizens-in-r/))
+
+Installation
+------------
 
 refactor is not available on CRAN but you can easily install the latest version from github using `devtools`:
 
-```R
+``` r
 # install.packages("devtools")
 devtools::install_github("jonmcalder/refactor")
 ```
 
-## Overview
+Overview
+--------
 
-Below are some of the highlights.  
+Below are some of the highlights.
 
+#### Better factor creation:
 
-#### Better factor creation:  
-  
-- sequences in strings are detected and used to order the factor levels automatically
-    - e.g. EUR11-20, EUR51-EUR60, EUR101-EUR110  
-    
-- get warnings whenever provided factor levels don't fully match those present in the data  
+-   sequences in strings are detected and used to order the factor levels automatically
+    -   e.g. EUR11-20, EUR51-EUR60, EUR101-EUR110
+-   get warnings whenever provided factor levels don't fully match those present in the data
 
+#### Extension of the generic `cut` method to handle (discrete) integer data:
 
-#### Extension of the generic `cut` method to handle (discrete) integer data:  
-  
-- generate 'natural' intervals for factors when using cut on integer vectors 
-    - e.g. [1,3], [4,6], [7,9] as opposed to (0.5, 3.5], (3.5, 6.5], (6.5, 9.5]  
-    
-- label factor levels more intuitively 
-    - e.g. 1-3, 4-6, 7-9 as opposed to [1,3], [4,6], [7,9], or (0,3], (3,6], (7-9]  
-    
+-   generate 'natural' intervals for factors when using cut on integer vectors
+    -   e.g. `[1,3], [4,6], [7,9]` as opposed to `(0.5, 3.5], (3.5, 6.5], (6.5, 9.5]`
+-   label factor levels more intuitively
+    -   e.g. 1-3, 4-6, 7-9 as opposed to \[1,3\], \[4,6\], \[7,9\], or (0,3\], (3,6\], (7-9\]
 
-## Contributions
+Contributions
+-------------
 
-Any suggestions and/or feedback is most welcome.  
-  
+Any suggestions and/or feedback is most welcome.
+
 Feel free to [open an issue](https://github.com/jonmcalder/refactor/issues) if you want to request a feature/report a bug, or make a pull request if you can contribute.

--- a/man/cfactor.Rd
+++ b/man/cfactor.Rd
@@ -30,20 +30,26 @@ cfactor(x, levels, labels = levels, exclude = NA, ordered = is.ordered(x),
 
 \item{nmax}{an upper bound on the number of levels; see \sQuote{Details}.}
 
-\item{sep}{A character vector giving all strings that are used to separate the lower numerical boundary of a range from the upper 
+\item{sep}{A character vector giving all strings that are used to separate 
+the lower numerical boundary of a range from the upper 
 numerical boundary within \code{x}.}
 }
 \value{
-An object of class "factor" which has a set of integer codes the length of \code{x} with a "levels" attribute of mode character
- and unique (!anyDuplicated(.)) entries. If argument ordered is true (or ordered() is used) the result has class c("ordered", "factor").
+An object of class "factor" which has a set of integer codes the 
+ length of \code{x} with a "levels" attribute of mode character
+ and unique (!anyDuplicated(.)) entries. If argument ordered is true (or 
+ ordered() is used) the result has class c("ordered", "factor").
 }
 \description{
 A wrapper for \code{factor} with enhanced control.
 }
 \details{
-\code{cfactor} wraps \code{\link{factor}} but provides enhanced control. \cr
- The order of the levels is determined by sorting the numerical values preceeding the separators indicated in \code{sep}. If 
- \code{sep} is set to \code{NULL} or if not every value of \code{x} contains numbers, the same ordering as in \code{factor} is applied.
+\code{cfactor} wraps \code{\link{factor}} but provides enhanced 
+ control. \cr
+ The order of the levels is determined by sorting the numerical values 
+ preceeding the separators indicated in \code{sep}. If 
+ \code{sep} is set to \code{NULL} or if not every value of \code{x} contains 
+ numbers, the same ordering as in \code{factor} is applied.
 }
 \examples{
 cfactor(c("a", "c", "b", "c", "d"))

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -16,29 +16,35 @@ single integer (greater than or equal to 2) giving the number of intervals
 into which \code{x} is to be cut.}
 
 \item{labels}{Labels for the levels of the resulting category. By default,
-labels are constructed using "a-b c-d" interval notation. If \code{labels =
-FALSE}, simple integer codes are returned instead of a factor.}
+labels are constructed using "a-b c-d" interval notation. If 
+\code{labels = FALSE}, simple integer codes are returned instead of a 
+factor.}
 
 \item{include.lowest}{Logical, indicating if an "x[i]" equal to the lowest
-(or highest, for \code{right = FALSE)} "breaks" value should be included. Note
-that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
-since this is more intuitive for integer intervals.}
+(or highest, for \code{right = FALSE)} "breaks" value should be included. 
+Note that unlike \code{\link[base]{cut.default}}, here 
+\code{include.lowest} defaults to \code{TRUE}, since this is more 
+intuitive for integer intervals.}
 
 \item{right}{Logical, indicating how to create the bins. This is utilized in
 two different ways based on the type of breaks argument. In the
 conventional case, where a breaks vector is supplied, \code{right = TRUE}
 indicates that bins should be closed on the right (and open on the left) or
-vice versa. If a single integer breaks value is provided, then \code{right = TRUE}
-indicates that bins will be determined such that those on the right are
-larger (if it is not possible for all bins to be evenly sized).}
+vice versa. If a single integer breaks value is provided, then 
+\code{right = TRUE} indicates that bins will be determined such that those 
+on the right are larger (if it is not possible for all bins to be evenly 
+sized).}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
-\item{breaks_mode}{A parameter indicating how to determine the intervals when
-breaks is specified as a scalar. \itemize{ \item 'default' will result in
-intervals spread as evenly as possible over the exact range of \code{x}. \item
-'pretty' will generate rounded breakpoints for the intervals (often
-extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}}
+\item{breaks_mode}{A parameter indicating how to determine the intervals 
+when breaks is specified as a scalar. 
+\itemize{ 
+  \item 'default' will result in intervals spread as evenly as possible 
+  over the exact range of \code{x}. 
+  \item 'pretty' will generate rounded breakpoints for the intervals (often
+  extending slightly beyond the range of \code{x}) based on 
+  \link[base]{pretty}.}}
 
 \item{label_sep}{A single or short character string used to generate labels
 for the intervals e.g. the default value of "-" will result in labels like
@@ -48,19 +54,20 @@ for the intervals e.g. the default value of "-" will result in labels like
 in particular to \code{\link{cut.default}}.}
 }
 \value{
-A factor is returned, unless \code{labels = FALSE} which results in an
-  integer vector of level codes.
+A factor is returned, unless \code{labels = FALSE} which results in 
+an integer vector of level codes.
 }
 \description{
 cut divides the range of \code{x} into intervals and codes the values in \code{x} according
 to the interval they fall into.
 }
 \details{
-In deviation from \code{cut.default}, \code{cut.integer} does not have
- an argument \code{dig.lab}, but instead has two arguments that do not exist
- for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
- Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
-  since this is more intuitive for integer intervals.
+In deviation from \code{cut.default}, \code{cut.integer} does not 
+ have an argument \code{dig.lab}, but instead has two arguments that do not 
+ exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+ Note that unlike \code{\link[base]{cut.default}}, here 
+ \code{include.lowest} defaults to \code{TRUE}, since this is more intuitive 
+ for integer intervals.
 }
 \examples{
 random <- sample(10)

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -33,7 +33,6 @@ such that those on the right are larger (if it is not possible for all bins to b
  \item 'default' will result in intervals spread as evenly as possible over the exact range of x
  \item 'pretty' will generate rounded breakpoints for the intervals (often extending slightly beyond the range of x) based on 
  \link[base]{pretty}
- \item 'quantile' will form the intervals so as to result in similar frequencies of occurrence in each of the intervals
 }}
 
 \item{label_sep}{A single or short character string used to generate labels for the intervals e.g. the default value of "-" 

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -11,39 +11,50 @@
 \arguments{
 \item{x}{A numeric vector which is to be converted to a factor by cutting.}
 
-\item{breaks}{Either an integer vector of two or more unique cut points or a single integer (greater than or equal to 2) giving the
-number of intervals into which x is to be cut.}
+\item{breaks}{Either an integer vector of two or more unique cut points or a
+single integer (greater than or equal to 2) giving the number of intervals
+into which x is to be cut.}
 
-\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using "a-b c-d" interval notation.
-If labels = FALSE, simple integer codes are returned instead of a factor.}
+\item{labels}{Labels for the levels of the resulting category. By default,
+labels are constructed using "a-b c-d" interval notation. If labels =
+FALSE, simple integer codes are returned instead of a factor.}
 
-\item{include.lowest}{Logical, indicating if an "x[i]" equal to the lowest (or highest, for right = FALSE) "breaks" value should be
-included. Note that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE, since this is more intuitive for integer 
-intervals.}
+\item{include.lowest}{Logical, indicating if an "x[i]" equal to the lowest
+(or highest, for right = FALSE) "breaks" value should be included. Note
+that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE,
+since this is more intuitive for integer intervals.}
 
-\item{right}{Logical, indicating how to create the bins. This is utilized in two different ways based on the type of breaks argument. 
-In the conventional case, where a breaks vector is supplied, right = TRUE indicates that bins should be closed on the right (and open 
-on the left) or vice versa. If a single integer breaks value is provided, then right = TRUE indicates that bins will be determined 
-such that those on the right are larger (if it is not possible for all bins to be evenly sized).}
+\item{right}{Logical, indicating how to create the bins. This is utilized in
+two different ways based on the type of breaks argument. In the
+conventional case, where a breaks vector is supplied, right = TRUE
+indicates that bins should be closed on the right (and open on the left) or
+vice versa. If a single integer breaks value is provided, then right = TRUE
+indicates that bins will be determined such that those on the right are
+larger (if it is not possible for all bins to be evenly sized).}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
-\item{breaks_mode}{A parameter indicating how to determine the intervals when breaks is specified as 
- a scalar. \itemize{
- \item 'default' will result in intervals spread as evenly as possible over the exact range of x
- \item 'pretty' will generate rounded breakpoints for the intervals (often extending slightly beyond the range of x) based on 
- \link[base]{pretty}
- \item 'quantile' will form the intervals so as to result in similar frequencies of occurrence in each of the intervals
-}}
+\item{breaks_mode}{A parameter indicating how to determine the intervals when
+breaks is specified as a scalar. \itemize{ \item 'default' will result in
+intervals spread as evenly as possible over the exact range of x \item
+'pretty' will generate rounded breakpoints for the intervals (often
+extending slightly beyond the range of x) based on \link[base]{pretty} 
+\item 'quantile' will form the intervals so as to result in similar
+frequencies of occurrence in each of the intervals }}
 
-\item{label_sep}{A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
-will result in labels like 1-10 11-20 21-30 etc}
+\item{label_sep}{A single or short character string used to generate labels
+for the intervals e.g. the default value of "-" will result in labels like
+1-10 11-20 21-30 etc}
+
+\item{...}{Further arguments to be passed to \code{\link{cut.default}}.}
 }
 \value{
-A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
+A factor is returned, unless labels = FALSE which results in an
+  integer vector of level codes.
 }
 \description{
-cut divides the range of x into intervals and codes the values in x according to the interval they fall into.
+cut divides the range of x into intervals and codes the values in x according
+to the interval they fall into.
 }
 \examples{
 Z <- sample(10)

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -15,16 +15,16 @@
 number of intervals into which x is to be cut.}
 
 \item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using "a-b c-d" interval notation.
-If labels = FALSE, simple integer codes are returned instead of a factor.}
+If \code{labels = FALSE}, simple integer codes are returned instead of a factor.}
 
-\item{include.lowest}{Logical, indicating if an "x[i]" equal to the lowest (or highest, for right = FALSE) "breaks" value should be
-included. Note that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE, since this is more intuitive for integer 
-intervals.}
+\item{include.lowest}{Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) \code{breaks} 
+value should be included. Note that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE, since this is more 
+intuitive for integer intervals.}
 
 \item{right}{Logical, indicating how to create the bins. This is utilized in two different ways based on the type of breaks argument. 
-In the conventional case, where a breaks vector is supplied, right = TRUE indicates that bins should be closed on the right (and open 
-on the left) or vice versa. If a single integer breaks value is provided, then right = TRUE indicates that bins will be determined 
-such that those on the right are larger (if it is not possible for all bins to be evenly sized).}
+In the conventional case, where a breaks vector is supplied, \code{right = TRUE} indicates that bins should be closed on the right 
+(and open on the left) or vice versa. If a single integer breaks value is provided, then right = TRUE indicates that bins will be 
+determined such that those on the right are larger (if it is not possible for all bins to be evenly sized).}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
@@ -37,6 +37,8 @@ such that those on the right are larger (if it is not possible for all bins to b
 
 \item{label_sep}{A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
 will result in labels like 1-10 11-20 21-30 etc}
+
+\item{...}{further arguments passed to or from other methods.}
 }
 \value{
 A factor is returned, unless labels = FALSE which results in an integer vector of level codes.

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/cut.integer.R
 \name{cut.integer}
 \alias{cut.integer}
-\title{Convert Numeric to Factor}
+\title{Create Bins for Numeric vectors}
 \usage{
 \method{cut}{integer}(x, breaks, labels = NULL, include.lowest = TRUE,
   right = TRUE, ordered_result = FALSE, breaks_mode = "default",
@@ -13,22 +13,22 @@
 
 \item{breaks}{Either an integer vector of two or more unique cut points or a
 single integer (greater than or equal to 2) giving the number of intervals
-into which x is to be cut.}
+into which \code{x} is to be cut.}
 
 \item{labels}{Labels for the levels of the resulting category. By default,
-labels are constructed using "a-b c-d" interval notation. If labels =
-FALSE, simple integer codes are returned instead of a factor.}
+labels are constructed using "a-b c-d" interval notation. If \code{labels =
+FALSE}, simple integer codes are returned instead of a factor.}
 
 \item{include.lowest}{Logical, indicating if an "x[i]" equal to the lowest
-(or highest, for right = FALSE) "breaks" value should be included. Note
-that unlike \link[base]{cut.default}, here include.lowest defaults to TRUE,
+(or highest, for \code{right = FALSE)} "breaks" value should be included. Note
+that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
 since this is more intuitive for integer intervals.}
 
 \item{right}{Logical, indicating how to create the bins. This is utilized in
 two different ways based on the type of breaks argument. In the
-conventional case, where a breaks vector is supplied, right = TRUE
+conventional case, where a breaks vector is supplied, \code{right = TRUE}
 indicates that bins should be closed on the right (and open on the left) or
-vice versa. If a single integer breaks value is provided, then right = TRUE
+vice versa. If a single integer breaks value is provided, then \code{right = TRUE}
 indicates that bins will be determined such that those on the right are
 larger (if it is not possible for all bins to be evenly sized).}
 
@@ -36,28 +36,34 @@ larger (if it is not possible for all bins to be evenly sized).}
 
 \item{breaks_mode}{A parameter indicating how to determine the intervals when
 breaks is specified as a scalar. \itemize{ \item 'default' will result in
-intervals spread as evenly as possible over the exact range of x \item
+intervals spread as evenly as possible over the exact range of \code{x}. \item
 'pretty' will generate rounded breakpoints for the intervals (often
-extending slightly beyond the range of x) based on \link[base]{pretty} 
-\item 'quantile' will form the intervals so as to result in similar
-frequencies of occurrence in each of the intervals }}
+extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}}
 
 \item{label_sep}{A single or short character string used to generate labels
 for the intervals e.g. the default value of "-" will result in labels like
-1-10 11-20 21-30 etc}
+1-10 11-20 21-30 etc.}
 
-\item{...}{Further arguments to be passed to \code{\link{cut.default}}.}
+\item{...}{Further arguments to be passed to or from other methods, 
+in particular to \code{\link{cut.default}}.}
 }
 \value{
-A factor is returned, unless labels = FALSE which results in an
+A factor is returned, unless \code{labels = FALSE} which results in an
   integer vector of level codes.
 }
 \description{
-cut divides the range of x into intervals and codes the values in x according
+cut divides the range of \code{x} into intervals and codes the values in \code{x} according
 to the interval they fall into.
 }
+\details{
+In deviation from \code{cut.default}, \code{cut.integer} does not have
+ an argument \code{dig.lab}, but instead has two arguments that do not exist
+ for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+ Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
+  since this is more intuitive for integer intervals.
+}
 \examples{
-Z <- sample(10)
- cut(Z, breaks = c(0, 5, 10))
+random <- sample(10)
+ cut(random, breaks = seq(0, 100, by = 10))[1:10]
 }
 

--- a/man/cut.ordered.Rd
+++ b/man/cut.ordered.Rd
@@ -11,43 +11,56 @@
 \arguments{
 \item{x}{A numeric vector which is to be converted to a factor by cutting.}
 
-\item{breaks}{Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
+\item{breaks}{Either a numeric vector of two or more unique cut points or a 
+ single number (greater than or equal to 2) giving the
 number of intervals into which \code{x} is to be cut.}
 
-\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using \code{a-b, c-d} interval notation.
-If \code{labels = FALSE}, simple integer codes are returned instead of a factor.}
+\item{labels}{Labels for the levels of the resulting category. By default, 
+labels are constructed using \code{a-b, c-d} interval notation.
+If \code{labels = FALSE}, simple integer codes are returned instead of a 
+factor.}
 
-\item{include.lowest}{Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) breaks value 
-should be included.}
+\item{include.lowest}{Logical, indicating if an \code{x[i]} equal to the 
+lowest (or highest, for \code{right = FALSE}) breaks value should be 
+included.}
 
-\item{right}{Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.}
+\item{right}{Logical, indicating if the intervals should be closed on the 
+right (and open on the left) or vice versa.}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
 \item{breaks_mode}{A parameter indicating how to determine the intervals when
-breaks is specified as a scalar. \itemize{ \item 'default' will result in
-intervals spread as evenly as possible over the exact range of \code{x}. \item
+breaks is specified as a scalar. 
+\itemize{ 
+ \item 'default' will result in
+ intervals spread as evenly as possible over the exact range of \code{x}. 
+ \item
 'pretty' will generate rounded breakpoints for the intervals (often
-extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}}
+extending slightly beyond the range of \code{x}) based on 
+\link[base]{pretty}.}}
 
-\item{label_sep}{A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
-will result in labels like a-c d-g i-z etc.}
+\item{label_sep}{A single or short character string used to generate labels 
+for the intervals e.g. the default value of "-" will result in labels like 
+a-c d-g i-z etc.}
 
 \item{...}{Further arguments to be passed to or from other methods, 
 in particular to \code{\link{cut.default}}.}
 }
 \value{
-A factor is returned, unless \code{labels = FALSE} which results in an integer vector of level codes.
+A factor is returned, unless \code{labels = FALSE} which results in 
+ an integer vector of level codes.
 }
 \description{
-cut divides the range of \code{x} into intervals and codes the values in \code{x} according to the interval they fall into.
+cut divides the range of \code{x} into intervals and codes the values in 
+ \code{x} according to the interval they fall into.
 }
 \details{
-In deviation from \code{cut.default}, \code{cut.ordered} does not have
- an argument \code{dig.lab}, but instead has two arguments that do not exist
- for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
- Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
-  since this is more intuitive for integer intervals.
+In deviation from \code{cut.default}, \code{cut.ordered} does not 
+ have an argument \code{dig.lab}, but instead has two arguments that do not 
+ exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+ Note that unlike \code{\link[base]{cut.default}}, here 
+ \code{include.lowest} defaults to \code{TRUE}, since this is more intuitive 
+ for integer intervals.
 }
 \examples{
  some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)

--- a/man/cut.ordered.Rd
+++ b/man/cut.ordered.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/cut.ordered.R
 \name{cut.ordered}
 \alias{cut.ordered}
-\title{Convert Numeric to Factor}
+\title{Create Bins for ordered Factors}
 \usage{
 \method{cut}{ordered}(x, breaks, labels = NULL, include.lowest = FALSE,
-  right = TRUE, digit.lab = 3, ordered_result = FALSE,
-  breaks_mode = "default", label_sep = "-", ...)
+  right = TRUE, ordered_result = FALSE, breaks_mode = "default",
+  label_sep = "-", ...)
 }
 \arguments{
 \item{x}{A numeric vector which is to be converted to a factor by cutting.}
 
 \item{breaks}{Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
-number of intervals into which x is to be cut.}
+number of intervals into which \code{x} is to be cut.}
 
-\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using \code{(a,b]} interval notation.
+\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using \code{a-b, c-d} interval notation.
 If \code{labels = FALSE}, simple integer codes are returned instead of a factor.}
 
 \item{include.lowest}{Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) breaks value 
@@ -22,21 +22,36 @@ should be included.}
 
 \item{right}{Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.}
 
-\item{digit.lab}{Integer which is used when labels are not given. It determines the number of digits used in formatting the break
-numbers.}
-
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
-\item{...}{further arguments passed to or from other methods.}
+\item{breaks_mode}{A parameter indicating how to determine the intervals when
+breaks is specified as a scalar. \itemize{ \item 'default' will result in
+intervals spread as evenly as possible over the exact range of \code{x}. \item
+'pretty' will generate rounded breakpoints for the intervals (often
+extending slightly beyond the range of \code{x}) based on \link[base]{pretty}.}}
+
+\item{label_sep}{A single or short character string used to generate labels for the intervals e.g. the default value of "-" 
+will result in labels like a-c d-g i-z etc.}
+
+\item{...}{Further arguments to be passed to or from other methods, 
+in particular to \code{\link{cut.default}}.}
 }
 \value{
-A factor is returned, unless labels = FALSE which results in an integer vector of level codes.
+A factor is returned, unless \code{labels = FALSE} which results in an integer vector of level codes.
 }
 \description{
-cut divides the range of x into intervals and codes the values in x according to the interval they fall into.
+cut divides the range of \code{x} into intervals and codes the values in \code{x} according to the interval they fall into.
+}
+\details{
+In deviation from \code{cut.default}, \code{cut.ordered} does not have
+ an argument \code{dig.lab}, but instead has two arguments that do not exist
+ for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+ Note that unlike \code{\link[base]{cut.default}}, here \code{include.lowest} defaults to \code{TRUE},
+  since this is more intuitive for integer intervals.
 }
 \examples{
-Z <- stats::rnorm(10000)
-cut(Z, breaks = -6:6)
+ some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
+ cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE)
+ 
 }
 

--- a/man/cut.ordered.Rd
+++ b/man/cut.ordered.Rd
@@ -51,7 +51,9 @@ In deviation from \code{cut.default}, \code{cut.ordered} does not have
 }
 \examples{
  some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
- cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE)
+ head(cut(some_letters, breaks = c("a", "q", "z"), 
+          labels = c("beginning of the alphabet", "the rest of the alphabeth"), 
+          right = TRUE, include.lowest = TRUE))
  
 }
 

--- a/man/cut.ordered.Rd
+++ b/man/cut.ordered.Rd
@@ -13,11 +13,11 @@
 \item{breaks}{Either a numeric vector of two or more unique cut points or a single number (greater than or equal to 2) giving the
 number of intervals into which x is to be cut.}
 
-\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using "(a,b]" interval notation.
-If labels = FALSE, simple integer codes are returned instead of a factor.}
+\item{labels}{Labels for the levels of the resulting category. By default, labels are constructed using \code{(a,b]} interval notation.
+If \code{labels = FALSE}, simple integer codes are returned instead of a factor.}
 
-\item{include.lowest}{Logical, indicating if an ‘x[i]’ equal to the lowest (or highest, for right = FALSE) ‘breaks’ value should be
-included.}
+\item{include.lowest}{Logical, indicating if an \code{x[i]} equal to the lowest (or highest, for \code{right = FALSE}) breaks value 
+should be included.}
 
 \item{right}{Logical, indicating if the intervals should be closed on the right (and open on the left) or vice versa.}
 
@@ -25,6 +25,8 @@ included.}
 numbers.}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
+
+\item{...}{further arguments passed to or from other methods.}
 }
 \value{
 A factor is returned, unless labels = FALSE which results in an integer vector of level codes.

--- a/man/index_cfactor.Rd
+++ b/man/index_cfactor.Rd
@@ -8,13 +8,15 @@ index_cfactor(data, index, variable = "variable", encoding = "encoding",
   label = "label", ...)
 }
 \arguments{
-\item{data}{A data.frame containing integers to decode.}
+\item{data}{A data frame containing integers to decode.}
 
-\item{index}{A data.frame containing the encoding for \code{data}.}
+\item{index}{A data frame containing the encoding for \code{data}.}
 
 \item{variable}{The name of the column in \code{index} that indicates the variable.}
 
 \item{encoding}{The name of the column in \code{index} that indicates the encoding.}
+
+\item{label}{The name of the column in \code{index} that indicates the label to be assigned.}
 
 \item{...}{Further arguments to pass to \code{\link{cfactor}}.}
 }

--- a/man/index_cfactor.Rd
+++ b/man/index_cfactor.Rd
@@ -16,7 +16,10 @@ index_cfactor(data, index, variable = "variable", encoding = "encoding",
 
 \item{encoding}{The name of the column in \code{index} that indicates the encoding.}
 
-\item{...}{Further arguments to pass to \code{\link{cfactor}}.}
+\item{label}{The name of the column in \code{index} that indicates the label that will be given.}
+
+\item{...}{Further arguments to be passed to or from other methods, 
+in particular to \code{\link{cfactor}}.}
 }
 \value{
 The original data frame is returned whereas the variables for which an encoding was provided are turned into (ordered) factors. All other columns are returned unmodified.
@@ -25,7 +28,7 @@ The original data frame is returned whereas the variables for which an encoding 
 Decode numerical columns in a data frame into (ordered) factors given the encoding in another data frame.
 }
 \details{
-Arguments passed via \code{...} to \code{cfactor} are recycled, but only if they can be recycled in full length. Otherwise, an error is thrown. 
+Arguments passed via \code{...} to \code{cfactor} are only recycled if of length 1. Otherwise, an error is thrown. 
  All arguments passed via \code{...} are applied in the order of the data columns but columns not to convert are skipped (see example).
 }
 \examples{

--- a/man/index_cfactor.Rd
+++ b/man/index_cfactor.Rd
@@ -10,26 +10,35 @@ index_cfactor(data, index, variable = "variable", encoding = "encoding",
 \arguments{
 \item{data}{A data frame containing at least one integer column to decode.}
 
-\item{index}{A data frame containing the names of the variable to encode, the encoding for \code{data} and labels to assign.}
+\item{index}{A data frame containing the names of the variable to encode, 
+the encoding for \code{data} and labels to assign.}
 
-\item{variable}{The name of the column in \code{index} that indicates the variable.}
+\item{variable}{The name of the column in \code{index} that indicates the 
+variable.}
 
-\item{encoding}{The name of the column in \code{index} that indicates the encoding.}
+\item{encoding}{The name of the column in \code{index} that indicates the 
+encoding.}
 
-\item{label}{The name of the column in \code{index} that indicates the label that will be given.}
+\item{label}{The name of the column in \code{index} that indicates the label 
+that will be given.}
 
 \item{...}{Further arguments to be passed to or from other methods, 
 in particular to \code{\link{cfactor}}.}
 }
 \value{
-The original data frame is returned whereas the variables for which an encoding was provided are turned into (ordered) factors. All other columns are returned unmodified.
+The original data frame is returned whereas the variables for which 
+ an encoding was provided are turned into (ordered) factors. All other 
+ columns are returned unmodified.
 }
 \description{
-Decode numerical columns in a data frame into (ordered) factors given the encoding in another data frame.
+Decode numerical columns in a data frame into (ordered) factors given the 
+ encoding in another data frame.
 }
 \details{
-Arguments passed via \code{...} to \code{cfactor} are only recycled if of length 1. Otherwise, an error is thrown. 
- All arguments passed via \code{...} are applied in the order of the data columns but columns not to convert are skipped (see example).
+Arguments passed via \code{...} to \code{cfactor} are only recycled 
+ if of length 1. Otherwise, an error is thrown. 
+ All arguments passed via \code{...} are applied in the order of the data 
+ columns but columns not to convert are skipped (see example).
 }
 \examples{
  data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),

--- a/man/index_cfactor.Rd
+++ b/man/index_cfactor.Rd
@@ -2,39 +2,44 @@
 % Please edit documentation in R/index_cfactor.R
 \name{index_cfactor}
 \alias{index_cfactor}
-\title{index_cfactor}
+\title{Decode numerical into categorical data}
 \usage{
 index_cfactor(data, index, variable = "variable", encoding = "encoding",
   label = "label", ...)
 }
 \arguments{
-\item{data}{A data frame containing integers to decode.}
+\item{data}{A data frame containing at least one integer column to decode.}
 
-\item{index}{A data frame containing the encoding for \code{data}.}
+\item{index}{A data frame containing the names of the variable to encode, the encoding for \code{data} and labels to assign.}
 
 \item{variable}{The name of the column in \code{index} that indicates the variable.}
 
 \item{encoding}{The name of the column in \code{index} that indicates the encoding.}
 
-\item{label}{The name of the column in \code{index} that indicates the label to be assigned.}
-
 \item{...}{Further arguments to pass to \code{\link{cfactor}}.}
 }
+\value{
+The original data frame is returned whereas the variables for which an encoding was provided are turned into (ordered) factors. All other columns are returned unmodified.
+}
 \description{
-Decode numerical data into (ordered) factors given the encoding
+Decode numerical columns in a data frame into (ordered) factors given the encoding in another data frame.
+}
+\details{
+Arguments passed via \code{...} to \code{cfactor} are recycled, but only if they can be recycled in full length. Otherwise, an error is thrown. 
+ All arguments passed via \code{...} are applied in the order of the data columns but columns not to convert are skipped (see example).
 }
 \examples{
-data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
+ data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
                    var2 = rep(1:2, 20),
                    var3 = sample(20),
                    var4 = 2, 
                    var5 = sample(row.names(USArrests), size = 20),
                    stringsAsFactors = FALSE)
 
-index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
+ index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
                    encoding = c(1:10, 1:2, 1:20),
                    label = c(letters[1:10], c("male", "female"), LETTERS[1:20]))
                    
-index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, TRUE, FALSE))
+ index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, TRUE, FALSE))
 }
 

--- a/man/refactor.Rd
+++ b/man/refactor.Rd
@@ -4,9 +4,17 @@
 \name{refactor}
 \alias{refactor}
 \alias{refactor-package}
-\title{refactor: Better factor handling for R}
+\title{Better factor handling for R}
 \description{
-refactor aims to provide better handling of factors by addressing some of the known problems and 
+\pkg{refactor} aims to provide better handling of factors by addressing some of the known problems and 
 short-comings with the existing toolset for working with factors in R.
+}
+\author{
+Lorenz Walthert \email{lorenz.walthert@icloud.com}, \cr
+ Jon Calder \email{jonmcalder@gmail.com} \cr \cr
+ Maintainer: Lorenz Walthert \email{lorenz.walthert@icloud.com}
+}
+\seealso{
+See \code{vignette("refactor", package = "refactor")} for an overview of the package.
 }
 

--- a/tests/testthat/test-factor_creation.R
+++ b/tests/testthat/test-factor_creation.R
@@ -12,7 +12,9 @@ test_that("cfactor returns a factor", {
 
 test_that("cfactor returns expected levels", {
   expect_equal(levels(case1), "x")
-  expect_equal(levels(case2), paste("letter", 1:26, sep = "")) # is this really desired
+  
+  # is this really desired?
+  expect_equal(levels(case2), paste("letter", 1:26, sep = "")) 
   expect_equal(levels(case3), letters)
 
 })

--- a/tests/testthat/test-index_factor_creation.R
+++ b/tests/testthat/test-index_factor_creation.R
@@ -1,16 +1,35 @@
 context("index_factor_creation")
-data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
+data <- data.frame(var1 = sample(rep(1:10, 20)),
                    var2 = rep(1:2, 20),
                    var3 = sample(20),
                    var4 = 2, 
                    var5 = sample(row.names(USArrests), size = 20),
+                   var6 = as.character(sample(x = 1:10, size = 20, replace = TRUE)),
                    stringsAsFactors = FALSE)
 
 index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
                     encoding = c(1:10, 1:2, 1:20),
                     label = c(letters[1:10], c("male", "female"), LETTERS[1:20]))
+# try encoding a non-numeric column
+index2 <- data.frame(var = "var5",
+                    encoding = c(1:10, 1:2, 1:20),
+                    label = c(letters[1:10], c("male", "female"), LETTERS[1:20]))
+
+index3 <- data.frame(var = rep(paste0("var", c(1:3, 6)), c(10, 2, 20, 10)),
+                    encoding = c(1:10, 1:2, 1:20, 1:10),
+                    label = c(letters[1:10], c("male", "female"), LETTERS[1:20], letters[1:10]))
+
+index4 <- data.frame(var = "var99",
+                     encoding = c(1:10, 1:2, 1:20),
+                     label = c(letters[1:10], c("male", "female"), LETTERS[1:20]))
+
+index5 <- data.frame(var = rep(c("var99", "var3", "var2"), c(10, 20, 2)),
+                     encoding = c(1:10, sample(20), 1:2),
+                     label = c(letters[1:10], letters[1:20], c("male", "female")))
+
 
 test_that("basics", {
+  # expect no error
   expect_error(index_cfactor(data = data, index = index, variable = "var"), NA)
   expect_error(index_cfactor(data = data, index = index, variable = "var", ordered = TRUE), NA)
   expect_error(index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, FALSE, FALSE)), NA)
@@ -18,9 +37,25 @@ test_that("basics", {
 
 
 test_that("error handling", {
+  
+  # invalid recycling
   expect_error(index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE,FALSE)), 
                 paste("argument 'ordered' is not recycled fully. Number of columns to be decoded should",
                 "match the length of 'ordered' or mulitiple thereof."))
+  # when the class is character, but it could be coreced to integer. Test not implemented though.
+  expect_error(index_cfactor(data = data, index = index3, variable = "var"),
+               "The following columns in 'data' cannot be decoded since they do not inherit from class numeric or integer: \n var6")
+  
+  # when the variables of index can't be found in data
+  expect_error(index_cfactor(data = data, index = index4, variable = "var"),
+               "The variables in 'index' do not match any of the variables in 'data'")
+})
+
+test_that("warnings", {
+  # not all variabels from index are used in data
+  expect_warning(index_cfactor(data = data, index = index5, variable = "var"), 
+                 "The following variables from 'index' are not found in 'data': \n var99")
 })
 
 # tests for ... behavior with cfactor not tested
+# when the class is character and it could not be coreced to integer. Test not implemented though.

--- a/tests/testthat/test-index_factor_creation.R
+++ b/tests/testthat/test-index_factor_creation.R
@@ -45,13 +45,7 @@ test_that("error handling", {
   # when the class is character, but it could be coreced to integer. Test not implemented though.
   expect_error(index_cfactor(data = data, index = index3, variable = "var"),
                "The following columns in 'data' cannot be decoded since they do not inherit from class numeric or integer: \n var6")
-  
-  # when the variables of index can't be found in data
-  expect_error(index_cfactor(data = data, index = index4, variable = "var"),
-               "The variables in 'index' do not match any of the variables in 'data'")
-})
 
-test_that("warnings", {
   # not all variabels from index are used in data
   expect_warning(index_cfactor(data = data, index = index5, variable = "var"), 
                  "The following variables from 'index' are not found in 'data': \n var99")

--- a/tests/testthat/test-index_factor_creation.R
+++ b/tests/testthat/test-index_factor_creation.R
@@ -40,8 +40,7 @@ test_that("error handling", {
   
   # invalid recycling
   expect_error(index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE,FALSE)), 
-                paste("argument 'ordered' is not recycled fully. Number of columns to be decoded should",
-                "match the length of 'ordered' or mulitiple thereof."))
+                paste("argument 'ordered has unexpected length. Only arguments of length 1 are recycled."))
   # when the class is character, but it could be coreced to integer. Test not implemented though.
   expect_error(index_cfactor(data = data, index = index3, variable = "var"),
                "The following columns in 'data' cannot be decoded since they do not inherit from class numeric or integer: \n var6")

--- a/tests/testthat/test-index_factor_creation.R
+++ b/tests/testthat/test-index_factor_creation.R
@@ -40,7 +40,7 @@ test_that("error handling", {
   
   # invalid recycling
   expect_error(index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE,FALSE)), 
-                paste("argument 'ordered has unexpected length. Only arguments of length 1 are recycled."))
+                paste("argument 'ordered' has unexpected length. Only arguments of length 1 are recycled."))
   # when the class is character, but it could be coreced to integer. Test not implemented though.
   expect_error(index_cfactor(data = data, index = index3, variable = "var"),
                "The following columns in 'data' cannot be decoded since they do not inherit from class numeric or integer: \n var6")

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -39,7 +39,9 @@ case23 <- cut(sample(10), breaks = 3, labels = F)
 
 # for extremely few values in breaks
 ## breaks as scalar
-case24 <- cut(sample(10), breaks = 1, labels = F) # desired outcome although not in line with cut.defalt
+
+case24 <- cut(sample(10), breaks = 1, labels = F) # desired outcome although 
+# not in line with cut.defalt
 case25 <- cut(sample(10), breaks = 1, labels = NULL)
 case26 <- cut(sample(10), breaks = 1, labels = "lion") 
 
@@ -57,7 +59,8 @@ case30 <- cut(sample(10), breaks = c(1L, 3L, 10L))
 # when breaks need to be rounded
 case31 <- cut(sample(10), breaks = c(1, 2.6, 5.1, 10))
 
-test_that("cut.integer returns same as cut.default but with better labels for length(break) > 1", {
+test_that(paste("cut.integer returns same as cut.default but with better", 
+                "labels for length(break) > 1"), {
   # right = T
   expect_equal(levels(case1), c("2-5", "6-10"))
   expect_equal(levels(case2), c("1-5", "6-10"))
@@ -74,7 +77,8 @@ test_that("cut.integer returns same as cut.default but with better labels for le
 
 
 
-test_that("cut.integer returns expected (natural) intervals with better labels for length(break) == 1", {
+test_that(paste("cut.integer returns expected (natural) intervals with better",  
+                "labels for length(break) == 1"), {
   
   # 1:10 - 2 breaks ("left & "right")
   expect_equal(levels(case5), c("1-5", "6-10"))
@@ -136,16 +140,20 @@ test_that("cut.integer error cases", {
   ## should not produce an error if breaks are already given
   expect_equal(levels(case21), c("0-1", "2-9"))
   
-  ## should produce an error if breaks > length(x), since integer bins can't be created if bins should contain at least two integers.
+  ## should produce an error if breaks > length(x), since integer bins can't be 
+  # created if bins should contain at least two integers.
   expect_error(cut(sample(2), breaks = 3), 
                "range too small for the number of breaks specified")
   expect_error(cut(sample(10), breaks = 3, labels = letters[1:4]), 
-               "if labels not 'NULL' and not 'F', it must be the same length as the number of bins resulting from 'breaks'")
+               paste("if labels not 'NULL' and not 'F', it must be the same", 
+                     "length as the number of bins resulting from 'breaks'"))
   expect_error(cut(sample(10), breaks = 3, labels = letters[1:99]), 
-               "if labels not 'NULL' and not 'F', it must be the same length as the number of bins resulting from 'breaks'")
+               paste("if labels not 'NULL' and not 'F', it must be the same", 
+                      "length as the number of bins resulting from 'breaks'"))
   # edge case
   expect_error(cut(sample(10), breaks = 1, labels = c("lion", "tiger")),
-    "if labels not 'NULL' and not 'F', it must be the same length as the number of bins resulting from 'breaks'")
+    paste("if labels not 'NULL' and not 'F', it must be the same length as the", 
+          "number of bins resulting from 'breaks'"))
   
 })
 
@@ -167,7 +175,9 @@ test_that("cut.integer warning cases", {
   
   # when bins with width 1 are produced
   expect_warning(cut(sample(10), breaks = c(1, 4, 6, 8, 9, 10)),
-                 "^this break specification produces [[:digit:]]+ bin\\(s\\) of width 1. The corresponding label\\(s\\) are: 9, 10")
+                 paste("^this break specification produces [[:digit:]]+", 
+                       "bin\\(s\\) of width 1. The corresponding label\\(s\\)", 
+                       "are: 9, 10"))
   
 })
 

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -177,3 +177,7 @@ test_that("cut.integer warning cases", {
 test_that("cut.integer if breaks outside range(x)", {
   # not yet finished
 }) 
+
+# what happens in binwidth 1 if none is this width (line 99)
+# not optimal:
+# cut(int_norep, breaks = c(1, 2, 3, 10), right = T, include.lowest = F)

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -117,7 +117,7 @@ test_that("cut.integer returns expected (natural) intervals with better labels f
   expect_equal(levels(case30), c("1-3", "4-10"))
 
   # when breaks need to be rounde
-  expect_equal(levels(case31), c("1-3", "4-5", "6-10"))
+  expect_equal(levels(case31), c("1-2", "3-5", "6-10"))
 })
 
 test_that("cut.integer with user-defined labels", {
@@ -163,7 +163,7 @@ test_that("cut.integer warning cases", {
   
   # when breaks are to be rounded to coerce to integers
   expect_warning(cut(sample(10), breaks = c(1, 2.6, 5.1, 10)), 
-                 "^When coerced to integers, the following breaks were rounded")
+                 "^When coerced to integers, the following breaks were truncated")
   
   # when bins with width 1 are produced
   expect_warning(cut(sample(10), breaks = c(1, 4, 6, 8, 9, 10)),

--- a/tests/testthat/test-ordered_cut.R
+++ b/tests/testthat/test-ordered_cut.R
@@ -1,26 +1,40 @@
-# library("testthat")
-# 
-# context("integer_cut")
-# 
-# # breaks_mode = 'default'
-# ## no labels
-# case1a <- cut(cfactor1, breaks = c("a", "q", "z"), right = T, include.lowest = T)
-# case2a <- cut(cfactor1, breaks = c("a", "q", "z"), right = F, include.lowest = T)
-# 
-# # custom labels
-# case1b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("group one", "group 2"), right = T, include.lowest = T)
-# case2b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("group one", "group 2"), right = F, include.lowest = T)
-# 
-# 
-# test_that("cut.ordered with breaks_mode = 'default'", {
-#   # simple cases
-#   expect_equal(levels(case1a), c("a-q", "r-z"))
-#   expect_equal(levels(case2a), c("a-r", "s-z"))
-# 
-#   # simple cases
-#   q_pos <- which(letters) == "q"
-#   expect_equal(case1b[1:q_pos], rep("group one", 1:q_pos))
-#   expect_equal(case1b[q_pos+1:length(case1b)], rep("group 2", (q_pos+1):length(case1b)))
-#   expect_equal(levels(case2b), c("a-r", "s-z"))
-# 
-# })
+library("testthat")
+
+context("ordered_cut")
+cfactor1 <- cfactor(sample(letters, 100, replace = T), ordered = T)
+cfactor2 <- cfactor(sample(letters[3:16], 100, replace = T), ordered = T)
+
+
+# breaks_mode = 'default'
+
+## no labels
+case1a <- cut(cfactor1, breaks = c("a", "q", "z"), right = T, include.lowest = T)
+case2a <- cut(cfactor1, breaks = c("a", "q", "z"), right = F, include.lowest = T)
+
+# custom labels
+case1b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("group one", "group 2"), right = T, include.lowest = T)
+case2b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("a first group", "another one"), right = F, include.lowest = T)
+
+
+test_that("cut.ordered with breaks_mode = 'default'", {
+  # simple cases
+  expect_equal(levels(case1a), c("a-q", "r-z"))
+  expect_equal(levels(case2a), c("a-p", "q-z"))
+  expect_equal(levels(case1b), c("group one", "group 2"))
+  expect_equal(levels(case2b), c("a first group", "another one"))
+
+  # simple cases
+  q_pos <- which(letters) == "q"
+  expect_equal(case1b[1:q_pos], rep("group one", 1:q_pos))
+  expect_equal(case1b[q_pos+1:length(case1b)], rep("group 2", (q_pos+1):length(case1b)))
+  expect_equal(levels(case2b), c("a-r", "s-z"))
+
+})
+
+
+
+# specify breaks out of range
+test_that("warnings", {
+  expect_warning(cut(cfactor1, breaks = c("a", "q", "y"), right = T, include.lowest = T), 
+                 "missing values generated")
+})

--- a/tests/testthat/test-ordered_cut.R
+++ b/tests/testthat/test-ordered_cut.R
@@ -12,8 +12,11 @@ case1a <- cut(cfactor1, breaks = c("a", "q", "z"), right = T, include.lowest = T
 case2a <- cut(cfactor1, breaks = c("a", "q", "z"), right = F, include.lowest = T)
 
 # custom labels
-case1b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("group one", "group 2"), right = T, include.lowest = T)
-case2b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("a first group", "another one"), right = F, include.lowest = T)
+case1b <- cut(cfactor1, breaks = c("a", "q", "z"), 
+              labels = c("group one", "group 2"), right = T, include.lowest = T)
+case2b <- cut(cfactor1, breaks = c("a", "q", "z"), 
+              labels = c("a first group", "another one"), 
+              right = F, include.lowest = T)
 
 
 
@@ -31,13 +34,15 @@ test_that("cut.ordered with breaks_mode = 'default'", {
 # specify breaks out of range
 test_that("warnings", {
   # breaks that create missing values
-  expect_warning(cut(cfactor1, breaks = c("a", "q", "y"), right = T, include.lowest = T), 
+  expect_warning(cut(cfactor1, breaks = c("a", "q", "y"), 
+                     right = T, include.lowest = T), 
                  "[[:digit:]] missing values generated")
 })
 
 test_that("errors", {
   # breaks that do not exist in data
-  expect_error(cut(cfactor2, breaks = c("a", "q", "y"), right = T, include.lowest = T), 
+  expect_error(cut(cfactor2, breaks = c("a", "q", "y"), 
+                   right = T, include.lowest = T), 
                  "specified breakpoints inexistent in data")
 })
 

--- a/tests/testthat/test-ordered_cut.R
+++ b/tests/testthat/test-ordered_cut.R
@@ -30,6 +30,14 @@ test_that("cut.ordered with breaks_mode = 'default'", {
 
 # specify breaks out of range
 test_that("warnings", {
+  # breaks that create missing values
   expect_warning(cut(cfactor1, breaks = c("a", "q", "y"), right = T, include.lowest = T), 
                  "[[:digit:]] missing values generated")
 })
+
+test_that("errors", {
+  # breaks that do not exist in data
+  expect_error(cut(cfactor2, breaks = c("a", "q", "y"), right = T, include.lowest = T), 
+                 "specified breakpoints inexistent in data")
+})
+

--- a/tests/testthat/test-ordered_cut.R
+++ b/tests/testthat/test-ordered_cut.R
@@ -16,18 +16,13 @@ case1b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("group one", "grou
 case2b <- cut(cfactor1, breaks = c("a", "q", "z"), labels = c("a first group", "another one"), right = F, include.lowest = T)
 
 
+
 test_that("cut.ordered with breaks_mode = 'default'", {
   # simple cases
   expect_equal(levels(case1a), c("a-q", "r-z"))
   expect_equal(levels(case2a), c("a-p", "q-z"))
   expect_equal(levels(case1b), c("group one", "group 2"))
   expect_equal(levels(case2b), c("a first group", "another one"))
-
-  # simple cases
-  q_pos <- which(letters) == "q"
-  expect_equal(case1b[1:q_pos], rep("group one", 1:q_pos))
-  expect_equal(case1b[q_pos+1:length(case1b)], rep("group 2", (q_pos+1):length(case1b)))
-  expect_equal(levels(case2b), c("a-r", "s-z"))
 
 })
 
@@ -36,5 +31,5 @@ test_that("cut.ordered with breaks_mode = 'default'", {
 # specify breaks out of range
 test_that("warnings", {
   expect_warning(cut(cfactor1, breaks = c("a", "q", "y"), right = T, include.lowest = T), 
-                 "missing values generated")
+                 "[[:digit:]] missing values generated")
 })

--- a/vignettes/refactor.R
+++ b/vignettes/refactor.R
@@ -11,35 +11,37 @@ cfactor(string, levels = c("b", "c", "d"))
 
 ## ------------------------------------------------------------------------
 easy_to_dectect <- c("EUR 11 - EUR 20", "EUR 1 - EUR 10", "EUR 21 - EUR 22")
-factor(easy_to_dectect, ordered = T) # correctly detects level
+factor(easy_to_dectect, ordered = TRUE) # correctly detects level
 
 ## ------------------------------------------------------------------------
-hard_to_dectect <- c("EUR 21 - EUR 22", "EUR 100 - 101", "EUR 1 - EUR 10", "EUR 11 - EUR 20")
-factor(hard_to_dectect, ordered = T)
+hard_to_dectect <- c("EUR 21 - EUR 22", "EUR 100 - 101", 
+                     "EUR 1 - EUR 10", "EUR 11 - EUR 20")
+
+factor(hard_to_dectect, ordered = TRUE)
 
 ## ------------------------------------------------------------------------
-cfactor(hard_to_dectect, ordered = T, sep = "-")
+cfactor(hard_to_dectect, ordered = TRUE, sep = "-")
 
 ## ------------------------------------------------------------------------
 identical(
-  cfactor(hard_to_dectect, ordered = T, sep = NULL),
-   factor(hard_to_dectect, ordered = T)
+  cfactor(hard_to_dectect, ordered = TRUE, sep = NULL),
+   factor(hard_to_dectect, ordered = TRUE)
 )
 
 ## ------------------------------------------------------------------------
-data <- sample(x = 1:10, size = 20, replace = T)
+data <- sample(x = 1:10, size = 20, replace = TRUE)
 index <- data.frame(encoding = 1:10,
                     label = letters[1:10])
 
 cfactor(data, levels = index$encoding, labels = index$label)
 
 ## ------------------------------------------------------------------------
-data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = T),
+data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
                   var2 = rep(1:2, 20),
                   var3 = sample(20),
                   var4 = 2, 
                   var5 = sample(row.names(USArrests), size = 20),
-                  stringsAsFactors = F)
+                  stringsAsFactors = FALSE)
 head(data)
 
 index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
@@ -48,11 +50,13 @@ index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
 head(index)
 
 ## ------------------------------------------------------------------------
-final <- head(index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, TRUE, FALSE)))
+final <- head(index_cfactor(data = data, index = index, variable = "var", 
+                            ordered = c(TRUE, TRUE, FALSE)))
+
 print(final)
 sapply(final, class)
 
-## ---- echo = F, include = T----------------------------------------------
+## ---- echo = FALSE, include = TRUE---------------------------------------
 c("1 to 4", "5 to 6") # properly separated
 c("1 to 4", "4 to 6") # not properly separated
 c("from 1,000 to 2,000", "from 2000 to 4,000") # comma separated and 'from' and 'to'
@@ -79,9 +83,8 @@ cut(sample(10), breaks = c(10, 0, 3))
 cut(sample(10), breaks = c(1, 2.6, 5.1, 10))
 
 ## ------------------------------------------------------------------------
-library(refactor)
-timeX <- c("very low", "rather low", "low", "medium", "upper medium", "high")
-time <- factor(timeX, levels = unique(timeX), ordered = T)
-
-cut(time, breaks = c("low", "medium", "high"))
+some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
+head(cut(some_letters, breaks = c("a", "q", "z"), 
+         labels = c("beginning of the alphabet", "the rest of the alphabeth"), 
+         right = TRUE, include.lowest = TRUE))
 

--- a/vignettes/refactor.Rmd
+++ b/vignettes/refactor.Rmd
@@ -29,8 +29,8 @@ One can note the following issues:
 
 The goal of the `refactor` package is to make working with factors more natural and fun by providing
 
-* the wrapper `cfactor` for `factor` to enhance control at the point of factor creation
-* a function `index_cfactor` to decode numerical data into (ordered) factors given the encoding
+* the wrapper `cfactor` for `factor` to enhance control at the point of factor creation.
+* a function `index_cfactor` to decode numerical data into (ordered) factors given the encoding.
 * S3 generics for existing R base classes (mainly `ordered` and `factor`) where current methods are not tailored for categorical data.
 
 ## `cfactor`

--- a/vignettes/refactor.Rmd
+++ b/vignettes/refactor.Rmd
@@ -21,6 +21,7 @@ upper <- factor(LETTERS[1:5], levels = LETTERS[1:4])
 ```
 
 
+
 One can note the following issues:
 
 * `factor()` does not yield an error when `NA`s are created silently, neither when levels do not match x nor when too few levels are specified. 
@@ -169,8 +170,6 @@ cut(sample(10), breaks = c(1, 2.6, 5.1, 10))
 This method allows one to combine the levels of a factor into fewer categories given some break points:
 ```{r}
 library(refactor)
-timeX <- c("very low", "rather low", "low", "medium", "upper medium", "high")
-time <- factor(timeX, levels = unique(timeX), ordered = T)
-
-cut(time, breaks = c("low", "medium", "high"))
+some_letters <- cfactor(sample(letters, 100, replace = T), ordered = T)
+cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = T, include.lowest = T)
 ```

--- a/vignettes/refactor.Rmd
+++ b/vignettes/refactor.Rmd
@@ -12,7 +12,11 @@ vignette: >
 
 ## Introduction
 
-Working with factors in R can be frustrating. As described well by [John Mount](http://www.win-vector.com/blog/2014/09/factors-are-not-first-class-citizens-in-r/), factors are not first-class citizens in R. Even the most basic code often behaves in an unexpected manner and without any warning. Let's start off with a simple example - creating two factor vectors and combining them together - that illustrates some of the issues:
+Working with factors in R can be frustrating. As described well by [John Mount](http://www.win-vector.com/blog/2014/09/factors-are-not-first-class-citizens-in-r/), 
+factors are not first-class citizens in R. Even the most basic code often 
+behaves in an unexpected manner and without any warning. Let's start off with a
+simple example - creating two factor vectors and combining them together - that
+illustrates some of the issues:
 
 ```{r}
 lower <- factor(letters[1:3], levels = letters[2:4])
@@ -24,18 +28,32 @@ upper <- factor(LETTERS[1:5], levels = LETTERS[1:4])
 
 One can note the following issues:
 
-* `factor()` does not yield an error when `NA`s are created silently, neither when levels do not match x nor when too few levels are specified. 
-* When `c()` is used to combine the two, the levels of the two elements (which are just attributes to integer vectors) are not conveyed, R simply combines the underlying integers from each vector.
-* This not only changes the data representation but fundamentally changes the data values and makes it impossible to restore the information. e.g. 1 now represents the first level of both `lower` and `upper`, so a 1 in the combined vector could be either `b` or an `A` from one of the original vectors.
+* `factor()` does not yield an error when `NA`s are created silently, neither 
+when levels do not match x nor when too few levels are specified. 
+* When `c()` is used to combine the two, the levels of the two elements (which 
+are just attributes to integer vectors) are not conveyed, R simply combines the
+underlying integers from each vector.
+* This not only changes the data representation but fundamentally changes the 
+data values and makes it impossible to restore the information. e.g. 1 now 
+represents the first level of both `lower` and `upper`, so a 1 in the combined 
+vector could be either `b` or an `A` from one of the original vectors.
 
-The goal of the `refactor` package is to make working with factors more natural and fun by providing
+The goal of the `refactor` package is to make working with factors more natural 
+and fun by providing
 
-* the wrapper `cfactor` for `factor` to enhance control at the point of factor creation.
-* a function `index_cfactor` to decode numerical data into (ordered) factors given the encoding.
-* S3 generics for existing R base classes (mainly `ordered` and `factor`) where current methods are not tailored for categorical data.
+* the wrapper `cfactor` for `factor` to enhance control at the point of factor 
+creation.
+* a function `index_cfactor` to decode numerical data into (ordered) factors 
+given the encoding.
+* S3 generics for existing R base classes (mainly `ordered` and `factor`) where 
+current methods are not tailored for categorical data.
 
 ## `cfactor`
-`cfactor` has been defined to give warnings in cases when empty factors are created from strings or when existing strings are not preserved. Essentially, it is a wrapper for `factor()`, and the 'c' stands for enhanced control. It also has improved level order detection based on numerical values within strings that is superior to the way `factor` assesses this order in certain cases.
+`cfactor` has been defined to give warnings in cases when empty factors are 
+created from strings or when existing strings are not preserved. Essentially, 
+it is a wrapper for `factor()`, and the 'c' stands for enhanced control. It also 
+has improved level order detection based on numerical values within strings that 
+is superior to the way `factor` assesses this order in certain cases.
 
 ### unmatched factors
 ```{r}
@@ -46,12 +64,17 @@ cfactor(string, levels = c("b", "c", "d"))
 ```
 
 ### detect levels
-The default behavior of `factor` (if levels are not explicitly supplied), is to first convert `x` to character, and then to take the unique values and sort the characters (`sort(unique(as.character(x)))`). This approach is fine if the string ordering was the same as ordering the numbers within the string, but in general this is not the case, as the following examples will illustrate:
+The default behavior of `factor` (if levels are not explicitly supplied), is to 
+first convert `x` to character, and then to take the unique values and sort the 
+characters (`sort(unique(as.character(x)))`). This approach is fine if the 
+string ordering was the same as ordering the numbers within the string, but in 
+general this is not the case, as the following examples will illustrate:
 
 \
 **A "clean" example**
 
-With all numbers having the same number of digits, `factor` can detect the order correctly.
+With all numbers having the same number of digits, `factor` can detect the order 
+correctly.
 ```{r}
 easy_to_dectect <- c("EUR 11 - EUR 20", "EUR 1 - EUR 10", "EUR 21 - EUR 22")
 factor(easy_to_dectect, ordered = TRUE) # correctly detects level
@@ -60,18 +83,26 @@ factor(easy_to_dectect, ordered = TRUE) # correctly detects level
 \
 **A more "dirty" example**
 
-However, in the general case, where number of digits might be destinct, this does not work anymore. The category "EUR 100 - 101" comes second, but it should be last.
+However, in the general case, where number of digits might be destinct, this 
+does not work anymore. The category "EUR 100 - 101" comes second, but it should 
+be last.
 ```{r}
-hard_to_dectect <- c("EUR 21 - EUR 22", "EUR 100 - 101", "EUR 1 - EUR 10", "EUR 11 - EUR 20")
+hard_to_dectect <- c("EUR 21 - EUR 22", "EUR 100 - 101", 
+                     "EUR 1 - EUR 10", "EUR 11 - EUR 20")
+
 factor(hard_to_dectect, ordered = TRUE)
 ```
 
-`cfactor` detects levels using regular expressions. Concretely, it extracts the substrings preceding `sep`, removes everything except digits and the decimal point in `x` and orders the remaining numbers to find the order of the levels.
+`cfactor` detects levels using regular expressions. Concretely, it extracts the 
+substrings preceding `sep`, removes everything except digits and the decimal 
+point in `x` and orders the remaining numbers to find the order of the levels.
 ```{r}
 cfactor(hard_to_dectect, ordered = TRUE, sep = "-")
 ```
 
-This detection algorithm can be turned off and the default ordering of `factor` can be applied by setting the `sep` argument to `NULL`. Also, in the absence of any numbers, the default ordering of `factor` is applied.
+This detection algorithm can be turned off and the default ordering of `factor` 
+can be applied by setting the `sep` argument to `NULL`. Also, in the absence of 
+any numbers, the default ordering of `factor` is applied.
 
 ```{r}
 identical(
@@ -82,7 +113,11 @@ identical(
 
 ## `index_cfactor`
 
-If data is encoded, the `labels` argument of `factor()` can be used to label the data, which is a common data pre-processing step. This works the same as with `cfactor()`. Here, we want to give an example where the relationship beteween the encoding and the label is stored in a `data.frame`, e.g. after it was imported from a spread sheet.
+If data is encoded, the `labels` argument of `factor()` can be used to label 
+the data, which is a common data pre-processing step. This works the same as 
+with `cfactor()`. Here, we want to give an example where the relationship b
+eteween the encoding and the label is stored in a `data.frame`, e.g. after it 
+was imported from a spread sheet.
 
 ```{r}
 data <- sample(x = 1:10, size = 20, replace = TRUE)
@@ -92,7 +127,9 @@ index <- data.frame(encoding = 1:10,
 cfactor(data, levels = index$encoding, labels = index$label)
 ```
 \
-In a real-world situation, it is likely that a lot of variables have to be decoded. `index_cfactor` was created to assist with this task. First, we need some sample data.
+In a real-world situation, it is likely that a lot of variables have to be 
+decoded. `index_cfactor` was created to assist with this task. First, we need 
+some sample data.
 ```{r}
 data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
                   var2 = rep(1:2, 20),
@@ -107,13 +144,21 @@ index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
                     label = c(letters[1:10], c("male", "female"), LETTERS[1:20]))
 head(index)
 ```
-Now we use `index_cfactor` to decode the `data.frame`. Note that `var4` and `var5` are left as is, since no variable encoding for them is defined in `index`. Using the `...` argument of `index_cfactor`, we can pass additional arguments to `cfactor`. 
+Now we use `index_cfactor` to decode the `data.frame`. Note that `var4` and 
+`var5` are left as is, since no variable encoding for them is defined in 
+`index`. Using the `...` argument of `index_cfactor`, we can pass additional 
+arguments to `cfactor`. 
 ```{r}
-final <- head(index_cfactor(data = data, index = index, variable = "var", ordered = c(TRUE, TRUE, FALSE)))
+final <- head(index_cfactor(data = data, index = index, variable = "var", 
+                            ordered = c(TRUE, TRUE, FALSE)))
+
 print(final)
 sapply(final, class)
 ```
-`index_cfactor` converts all columns in `data` that have a match in `index` to factors with the respective encoding using `cfactor`. Further arguments are `variable`, `label` and `encoding` referring to the column names in index that contain the respective information.
+`index_cfactor` converts all columns in `data` that have a match in `index` to 
+factors with the respective encoding using `cfactor`. Further arguments are 
+`variable`, `label` and `encoding` referring to the column names in index that 
+contain the respective information.
 
 **Other example strings**
 ```{r, echo = FALSE, include = TRUE}
@@ -125,10 +170,14 @@ c("one minute", "three minutes", "1 hour")
 ```
 
 ## tailored methods for categorical data
-Instead of defining completely new functions, we decided to provide some S3 generics to extend the functionality of existing R functions and tailor them so they are better suited for categorical data. Also, a more extensive warning and error behavior than for their base R counterparts is implemented. 
+Instead of defining completely new functions, we decided to provide some S3 
+generics to extend the functionality of existing R functions and tailor them so 
+they are better suited for categorical data. Also, a more extensive warning and 
+error behavior than for their base R counterparts is implemented. 
 
 ### `cut`
-Applying cut can result in categorical data, for example if integers are binned or if ordered factor levels are summarized into larger categories.
+Applying cut can result in categorical data, for example if integers are binned 
+or if ordered factor levels are summarized into larger categories.
 
 #### a `cut` method for integers
 `cut.default` provides rather inappropriate labels for integer values.
@@ -137,12 +186,14 @@ random <- sample(100)
 cut.default(random, breaks = seq(0, 100, by = 10))[1:10]
 ```
 
-`refactor` extends the S3 method `cut` with `cut.integer` to provide more natural labels for this data type.
+`refactor` extends the S3 method `cut` with `cut.integer` to provide more 
+natural labels for this data type.
 ```{r}
 cut(random, breaks = seq(0, 100, by = 10))[1:10]
 ```
 
-The remainder of the section will outline and describe how `cut.integer` deviates from the default `cut` method.    
+The remainder of the section will outline and describe how `cut.integer` 
+deviates from the default `cut` method.    
 <br><br>
 Creating missing values will yield a warning.
 
@@ -150,7 +201,9 @@ Creating missing values will yield a warning.
 cut(sample(10), breaks = c(0, 3, 5))
 ```
 
-It is possible to define bins with width 1. This will generate a label with just the value of the integer containted (e.g. 2 instead of 2-2) and issue a warning.
+It is possible to define bins with width 1. This will generate a label with 
+just the value of the integer containted (e.g. 2 instead of 2-2) and issue a 
+warning.
 ```{r}
 cut(sample(10), breaks = c(1, 4, 6, 8, 9, 10))
 ```
@@ -160,15 +213,19 @@ Unordered breaks will be ordered before proceeding and a warning will be issued.
 cut(sample(10), breaks = c(10, 0, 3))
 ```
 
-Decimal values for `breaks` will be rounded to integers and a warning will be issued.
+Decimal values for `breaks` will be rounded to integers and a warning will be 
+issued.
 ```{r}
 cut(sample(10), breaks = c(1, 2.6, 5.1, 10))
 ```
 
 
 #### a `cut` method for ordered factors
-This method allows one to combine the levels of a factor into fewer categories given some break points:
+This method allows one to combine the levels of a factor into fewer categories 
+given some break points:
 ```{r}
 some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
-head(cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE))
+head(cut(some_letters, breaks = c("a", "q", "z"), 
+         labels = c("beginning of the alphabet", "the rest of the alphabeth"), 
+         right = TRUE, include.lowest = TRUE))
 ```

--- a/vignettes/refactor.Rmd
+++ b/vignettes/refactor.Rmd
@@ -54,7 +54,7 @@ The default behavior of `factor` (if levels are not explicitly supplied), is to 
 With all numbers having the same number of digits, `factor` can detect the order correctly.
 ```{r}
 easy_to_dectect <- c("EUR 11 - EUR 20", "EUR 1 - EUR 10", "EUR 21 - EUR 22")
-factor(easy_to_dectect, ordered = T) # correctly detects level
+factor(easy_to_dectect, ordered = TRUE) # correctly detects level
 ```
 
 \
@@ -63,20 +63,20 @@ factor(easy_to_dectect, ordered = T) # correctly detects level
 However, in the general case, where number of digits might be destinct, this does not work anymore. The category "EUR 100 - 101" comes second, but it should be last.
 ```{r}
 hard_to_dectect <- c("EUR 21 - EUR 22", "EUR 100 - 101", "EUR 1 - EUR 10", "EUR 11 - EUR 20")
-factor(hard_to_dectect, ordered = T)
+factor(hard_to_dectect, ordered = TRUE)
 ```
 
 `cfactor` detects levels using regular expressions. Concretely, it extracts the substrings preceding `sep`, removes everything except digits and the decimal point in `x` and orders the remaining numbers to find the order of the levels.
 ```{r}
-cfactor(hard_to_dectect, ordered = T, sep = "-")
+cfactor(hard_to_dectect, ordered = TRUE, sep = "-")
 ```
 
 This detection algorithm can be turned off and the default ordering of `factor` can be applied by setting the `sep` argument to `NULL`. Also, in the absence of any numbers, the default ordering of `factor` is applied.
 
 ```{r}
 identical(
-  cfactor(hard_to_dectect, ordered = T, sep = NULL),
-   factor(hard_to_dectect, ordered = T)
+  cfactor(hard_to_dectect, ordered = TRUE, sep = NULL),
+   factor(hard_to_dectect, ordered = TRUE)
 )
 ```
 
@@ -85,7 +85,7 @@ identical(
 If data is encoded, the `labels` argument of `factor()` can be used to label the data, which is a common data pre-processing step. This works the same as with `cfactor()`. Here, we want to give an example where the relationship beteween the encoding and the label is stored in a `data.frame`, e.g. after it was imported from a spread sheet.
 
 ```{r}
-data <- sample(x = 1:10, size = 20, replace = T)
+data <- sample(x = 1:10, size = 20, replace = TRUE)
 index <- data.frame(encoding = 1:10,
                     label = letters[1:10])
 
@@ -94,12 +94,12 @@ cfactor(data, levels = index$encoding, labels = index$label)
 \
 In a real-world situation, it is likely that a lot of variables have to be decoded. `index_cfactor` was created to assist with this task. First, we need some sample data.
 ```{r}
-data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = T),
+data <- data.frame(var1 = sample(x = 1:10, size = 20, replace = TRUE),
                   var2 = rep(1:2, 20),
                   var3 = sample(20),
                   var4 = 2, 
                   var5 = sample(row.names(USArrests), size = 20),
-                  stringsAsFactors = F)
+                  stringsAsFactors = FALSE)
 head(data)
 
 index <- data.frame(var = rep(paste0("var", 1:3), c(10, 2, 20)),
@@ -116,7 +116,7 @@ sapply(final, class)
 `index_cfactor` converts all columns in `data` that have a match in `index` to factors with the respective encoding using `cfactor`. Further arguments are `variable`, `label` and `encoding` referring to the column names in index that contain the respective information.
 
 **Other example strings**
-```{r, echo = F, include = T}
+```{r, echo = FALSE, include = TRUE}
 c("1 to 4", "5 to 6") # properly separated
 c("1 to 4", "4 to 6") # not properly separated
 c("from 1,000 to 2,000", "from 2000 to 4,000") # comma separated and 'from' and 'to'
@@ -170,6 +170,6 @@ cut(sample(10), breaks = c(1, 2.6, 5.1, 10))
 This method allows one to combine the levels of a factor into fewer categories given some break points:
 ```{r}
 library(refactor)
-some_letters <- cfactor(sample(letters, 100, replace = T), ordered = T)
-cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = T, include.lowest = T)
+some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
+cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE)
 ```

--- a/vignettes/refactor.Rmd
+++ b/vignettes/refactor.Rmd
@@ -169,7 +169,6 @@ cut(sample(10), breaks = c(1, 2.6, 5.1, 10))
 #### a `cut` method for ordered factors
 This method allows one to combine the levels of a factor into fewer categories given some break points:
 ```{r}
-library(refactor)
 some_letters <- cfactor(sample(letters, 100, replace = TRUE), ordered = TRUE)
-cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE)
+head(cut(some_letters, breaks = c("a", "q", "z"), labels = c("beginning of the alphabet", "the rest of the alphabeth"), right = TRUE, include.lowest = TRUE))
 ```

--- a/vignettes/refactor.html
+++ b/vignettes/refactor.html
@@ -80,7 +80,8 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">lower &lt;-<span class="st"> </span><span class="kw">factor</span>(letters[<span class="dv">1</span>:<span class="dv">3</span>], <span class="dt">levels =</span> letters[<span class="dv">2</span>:<span class="dv">4</span>])
 upper &lt;-<span class="st"> </span><span class="kw">factor</span>(LETTERS[<span class="dv">1</span>:<span class="dv">5</span>], <span class="dt">levels =</span> LETTERS[<span class="dv">1</span>:<span class="dv">4</span>])
 (combined &lt;-<span class="st"> </span><span class="kw">c</span>(lower, upper))</code></pre></div>
-<pre><code>## [1] NA  1  2  1  2  3  4 NA</code></pre>
+<pre><code>## [1] &lt;NA&gt; b    c    A    B    C    D    &lt;NA&gt;
+## Levels: A b B c C D</code></pre>
 <p>One can note the following issues:</p>
 <ul>
 <li><code>factor()</code> does not yield an error when <code>NA</code>s are created silently, neither when levels do not match x nor when too few levels are specified.</li>
@@ -123,7 +124,9 @@ string &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">
 <p><br />
 <strong>A more “dirty” example</strong></p>
 <p>However, in the general case, where number of digits might be destinct, this does not work anymore. The category “EUR 100 - 101” comes second, but it should be last.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">hard_to_dectect &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">&quot;EUR 21 - EUR 22&quot;</span>, <span class="st">&quot;EUR 100 - 101&quot;</span>, <span class="st">&quot;EUR 1 - EUR 10&quot;</span>, <span class="st">&quot;EUR 11 - EUR 20&quot;</span>)
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">hard_to_dectect &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">&quot;EUR 21 - EUR 22&quot;</span>, <span class="st">&quot;EUR 100 - 101&quot;</span>, 
+                     <span class="st">&quot;EUR 1 - EUR 10&quot;</span>, <span class="st">&quot;EUR 11 - EUR 20&quot;</span>)
+
 <span class="kw">factor</span>(hard_to_dectect, <span class="dt">ordered =</span> <span class="ot">TRUE</span>)</code></pre></div>
 <pre><code>## [1] EUR 21 - EUR 22 EUR 100 - 101   EUR 1 - EUR 10  EUR 11 - EUR 20
 ## 4 Levels: EUR 1 - EUR 10 &lt; EUR 100 - 101 &lt; ... &lt; EUR 21 - EUR 22</code></pre>
@@ -141,13 +144,13 @@ string &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">
 </div>
 <div id="index_cfactor" class="section level2">
 <h2><code>index_cfactor</code></h2>
-<p>If data is encoded, the <code>labels</code> argument of <code>factor()</code> can be used to label the data, which is a common data pre-processing step. This works the same as with <code>cfactor()</code>. Here, we want to give an example where the relationship beteween the encoding and the label is stored in a <code>data.frame</code>, e.g. after it was imported from a spread sheet.</p>
+<p>If data is encoded, the <code>labels</code> argument of <code>factor()</code> can be used to label the data, which is a common data pre-processing step. This works the same as with <code>cfactor()</code>. Here, we want to give an example where the relationship b eteween the encoding and the label is stored in a <code>data.frame</code>, e.g. after it was imported from a spread sheet.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">data &lt;-<span class="st"> </span><span class="kw">sample</span>(<span class="dt">x =</span> <span class="dv">1</span>:<span class="dv">10</span>, <span class="dt">size =</span> <span class="dv">20</span>, <span class="dt">replace =</span> <span class="ot">TRUE</span>)
 index &lt;-<span class="st"> </span><span class="kw">data.frame</span>(<span class="dt">encoding =</span> <span class="dv">1</span>:<span class="dv">10</span>,
                     <span class="dt">label =</span> letters[<span class="dv">1</span>:<span class="dv">10</span>])
 
 <span class="kw">cfactor</span>(data, <span class="dt">levels =</span> index$encoding, <span class="dt">labels =</span> index$label)</code></pre></div>
-<pre><code>##  [1] h h d j h e h d i f g e h a b f c a j f
+<pre><code>##  [1] f i a f a d e c j b a g h a g h c i d e
 ## Levels: a b c d e f g h i j</code></pre>
 <p><br />
 In a real-world situation, it is likely that a lot of variables have to be decoded. <code>index_cfactor</code> was created to assist with this task. First, we need some sample data.</p>
@@ -159,12 +162,12 @@ In a real-world situation, it is likely that a lot of variables have to be decod
                   <span class="dt">stringsAsFactors =</span> <span class="ot">FALSE</span>)
 <span class="kw">head</span>(data)</code></pre></div>
 <pre><code>##   var1 var2 var3 var4          var5
-## 1    7    1    9    2       Alabama
-## 2    8    2    8    2     Tennessee
-## 3    8    1   18    2      Delaware
-## 4    6    2   10    2    New Jersey
-## 5    9    1    4    2      Oklahoma
-## 6    3    2   17    2 New Hampshire</code></pre>
+## 1    2    1    3    2       Vermont
+## 2    7    2   13    2         Texas
+## 3    1    1   19    2       Wyoming
+## 4    6    2    8    2       Georgia
+## 5    9    1    1    2 West Virginia
+## 6    7    2   12    2 Massachusetts</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">index &lt;-<span class="st"> </span><span class="kw">data.frame</span>(<span class="dt">var =</span> <span class="kw">rep</span>(<span class="kw">paste0</span>(<span class="st">&quot;var&quot;</span>, <span class="dv">1</span>:<span class="dv">3</span>), <span class="kw">c</span>(<span class="dv">10</span>, <span class="dv">2</span>, <span class="dv">20</span>)),
                     <span class="dt">encoding =</span> <span class="kw">c</span>(<span class="dv">1</span>:<span class="dv">10</span>, <span class="dv">1</span>:<span class="dv">2</span>, <span class="dv">1</span>:<span class="dv">20</span>),
                     <span class="dt">label =</span> <span class="kw">c</span>(letters[<span class="dv">1</span>:<span class="dv">10</span>], <span class="kw">c</span>(<span class="st">&quot;male&quot;</span>, <span class="st">&quot;female&quot;</span>), LETTERS[<span class="dv">1</span>:<span class="dv">20</span>]))
@@ -177,17 +180,19 @@ In a real-world situation, it is likely that a lot of variables have to be decod
 ## 5 var1        5     e
 ## 6 var1        6     f</code></pre>
 <p>Now we use <code>index_cfactor</code> to decode the <code>data.frame</code>. Note that <code>var4</code> and <code>var5</code> are left as is, since no variable encoding for them is defined in <code>index</code>. Using the <code>...</code> argument of <code>index_cfactor</code>, we can pass additional arguments to <code>cfactor</code>.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">final &lt;-<span class="st"> </span><span class="kw">head</span>(<span class="kw">index_cfactor</span>(<span class="dt">data =</span> data, <span class="dt">index =</span> index, <span class="dt">variable =</span> <span class="st">&quot;var&quot;</span>, <span class="dt">ordered =</span> <span class="kw">c</span>(<span class="ot">TRUE</span>, <span class="ot">TRUE</span>, <span class="ot">FALSE</span>)))</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">final &lt;-<span class="st"> </span><span class="kw">head</span>(<span class="kw">index_cfactor</span>(<span class="dt">data =</span> data, <span class="dt">index =</span> index, <span class="dt">variable =</span> <span class="st">&quot;var&quot;</span>, 
+                            <span class="dt">ordered =</span> <span class="kw">c</span>(<span class="ot">TRUE</span>, <span class="ot">TRUE</span>, <span class="ot">FALSE</span>)))</code></pre></div>
 <pre><code>## Warning: the following levels were empty: 
-##  10</code></pre>
+##  4
+## 8</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">print</span>(final)</code></pre></div>
 <pre><code>##   var1   var2 var3 var4          var5
-## 1    g   male    I    2       Alabama
-## 2    h female    H    2     Tennessee
-## 3    h   male    R    2      Delaware
-## 4    f female    J    2    New Jersey
-## 5    i   male    D    2      Oklahoma
-## 6    c female    Q    2 New Hampshire</code></pre>
+## 1    b   male    C    2       Vermont
+## 2    g female    M    2         Texas
+## 3    a   male    S    2       Wyoming
+## 4    f female    H    2       Georgia
+## 5    i   male    A    2 West Virginia
+## 6    g female    L    2 Massachusetts</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">sapply</span>(final, class)</code></pre></div>
 <pre><code>## $var1
 ## [1] &quot;ordered&quot; &quot;factor&quot; 
@@ -222,32 +227,32 @@ In a real-world situation, it is likely that a lot of variables have to be decod
 <p><code>cut.default</code> provides rather inappropriate labels for integer values.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">random &lt;-<span class="st"> </span><span class="kw">sample</span>(<span class="dv">100</span>)
 <span class="kw">cut.default</span>(random, <span class="dt">breaks =</span> <span class="kw">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dt">by =</span> <span class="dv">10</span>))[<span class="dv">1</span>:<span class="dv">10</span>]</code></pre></div>
-<pre><code>##  [1] (80,90]  (60,70]  (0,10]   (10,20]  (0,10]   (30,40]  (70,80] 
-##  [8] (90,100] (90,100] (10,20] 
+<pre><code>##  [1] (60,70] (50,60] (30,40] (10,20] (70,80] (80,90] (0,10]  (30,40]
+##  [9] (60,70] (60,70]
 ## 10 Levels: (0,10] (10,20] (20,30] (30,40] (40,50] (50,60] ... (90,100]</code></pre>
 <p><code>refactor</code> extends the S3 method <code>cut</code> with <code>cut.integer</code> to provide more natural labels for this data type.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(random, <span class="dt">breaks =</span> <span class="kw">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dt">by =</span> <span class="dv">10</span>))[<span class="dv">1</span>:<span class="dv">10</span>]</code></pre></div>
-<pre><code>##  [1] 81-90  61-70  0-10   11-20  0-10   31-40  71-80  91-100 91-100 11-20 
+<pre><code>##  [1] 61-70 51-60 31-40 11-20 71-80 81-90 0-10  31-40 61-70 61-70
 ## Levels: 0-10 11-20 21-30 31-40 41-50 51-60 61-70 71-80 81-90 91-100</code></pre>
 <p>The remainder of the section will outline and describe how <code>cut.integer</code> deviates from the default <code>cut</code> method.<br />
 <br><br> Creating missing values will yield a warning.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">0</span>, <span class="dv">3</span>, <span class="dv">5</span>))</code></pre></div>
 <pre><code>## Warning in cut.integer(sample(10), breaks = c(0, 3, 5)): 5 missing values
 ## generated</code></pre>
-<pre><code>##  [1] &lt;NA&gt; &lt;NA&gt; &lt;NA&gt; 4-5  &lt;NA&gt; 0-3  0-3  4-5  &lt;NA&gt; 0-3 
+<pre><code>##  [1] &lt;NA&gt; &lt;NA&gt; &lt;NA&gt; 4-5  0-3  &lt;NA&gt; 0-3  &lt;NA&gt; 4-5  0-3 
 ## Levels: 0-3 4-5</code></pre>
 <p>It is possible to define bins with width 1. This will generate a label with just the value of the integer containted (e.g. 2 instead of 2-2) and issue a warning.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">1</span>, <span class="dv">4</span>, <span class="dv">6</span>, <span class="dv">8</span>, <span class="dv">9</span>, <span class="dv">10</span>))</code></pre></div>
 <pre><code>## Warning in cut.integer(sample(10), breaks = c(1, 4, 6, 8, 9, 10)): this
 ## break specification produces 2 bin(s) of width 1. The corresponding
 ## label(s) are: 9, 10</code></pre>
-<pre><code>##  [1] 7-8 5-6 9   1-4 5-6 1-4 1-4 10  7-8 1-4
+<pre><code>##  [1] 10  1-4 7-8 1-4 5-6 1-4 5-6 1-4 7-8 9  
 ## Levels: 1-4 5-6 7-8 9 10</code></pre>
 <p>Unordered breaks will be ordered before proceeding and a warning will be issued.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">10</span>, <span class="dv">0</span>, <span class="dv">3</span>))</code></pre></div>
 <pre><code>## Warning in cut.integer(sample(10), breaks = c(10, 0, 3)): breaks were
 ## unsorted and are now sorted in the following order: 0 3 10</code></pre>
-<pre><code>##  [1] 4-10 4-10 0-3  4-10 0-3  4-10 4-10 0-3  4-10 4-10
+<pre><code>##  [1] 4-10 0-3  4-10 4-10 4-10 4-10 0-3  4-10 4-10 0-3 
 ## Levels: 0-3 4-10</code></pre>
 <p>Decimal values for <code>breaks</code> will be rounded to integers and a warning will be issued.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">1</span>, <span class="fl">2.6</span>, <span class="fl">5.1</span>, <span class="dv">10</span>))</code></pre></div>
@@ -255,65 +260,19 @@ In a real-world situation, it is likely that a lot of variables have to be decod
 ##   2.6 to 2  
 ##   5.1 to 5  
 ## </code></pre>
-<pre><code>##  [1] 1-2  6-10 6-10 3-5  3-5  6-10 3-5  6-10 1-2  6-10
+<pre><code>##  [1] 3-5  6-10 3-5  6-10 6-10 3-5  6-10 6-10 1-2  1-2 
 ## Levels: 1-2 3-5 6-10</code></pre>
 </div>
 <div id="a-cut-method-for-ordered-factors" class="section level4">
 <h4>a <code>cut</code> method for ordered factors</h4>
 <p>This method allows one to combine the levels of a factor into fewer categories given some break points:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(refactor)
-some_letters &lt;-<span class="st"> </span><span class="kw">cfactor</span>(<span class="kw">sample</span>(letters, <span class="dv">100</span>, <span class="dt">replace =</span> <span class="ot">TRUE</span>), <span class="dt">ordered =</span> <span class="ot">TRUE</span>)
-<span class="kw">cut</span>(some_letters, <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;q&quot;</span>, <span class="st">&quot;z&quot;</span>), <span class="dt">labels =</span> <span class="kw">c</span>(<span class="st">&quot;beginning of the alphabet&quot;</span>, <span class="st">&quot;the rest of the alphabeth&quot;</span>), <span class="dt">right =</span> <span class="ot">TRUE</span>, <span class="dt">include.lowest =</span> <span class="ot">TRUE</span>)</code></pre></div>
-<pre><code>##   [1] the rest of the alphabeth beginning of the alphabet
-##   [3] beginning of the alphabet the rest of the alphabeth
-##   [5] beginning of the alphabet beginning of the alphabet
-##   [7] the rest of the alphabeth the rest of the alphabeth
-##   [9] beginning of the alphabet the rest of the alphabeth
-##  [11] the rest of the alphabeth beginning of the alphabet
-##  [13] beginning of the alphabet the rest of the alphabeth
-##  [15] beginning of the alphabet the rest of the alphabeth
-##  [17] beginning of the alphabet beginning of the alphabet
-##  [19] beginning of the alphabet the rest of the alphabeth
-##  [21] the rest of the alphabeth beginning of the alphabet
-##  [23] beginning of the alphabet beginning of the alphabet
-##  [25] beginning of the alphabet the rest of the alphabeth
-##  [27] beginning of the alphabet the rest of the alphabeth
-##  [29] beginning of the alphabet beginning of the alphabet
-##  [31] beginning of the alphabet beginning of the alphabet
-##  [33] beginning of the alphabet beginning of the alphabet
-##  [35] the rest of the alphabeth beginning of the alphabet
-##  [37] beginning of the alphabet the rest of the alphabeth
-##  [39] beginning of the alphabet beginning of the alphabet
-##  [41] beginning of the alphabet beginning of the alphabet
-##  [43] beginning of the alphabet the rest of the alphabeth
-##  [45] the rest of the alphabeth beginning of the alphabet
-##  [47] the rest of the alphabeth beginning of the alphabet
-##  [49] beginning of the alphabet the rest of the alphabeth
-##  [51] beginning of the alphabet the rest of the alphabeth
-##  [53] beginning of the alphabet the rest of the alphabeth
-##  [55] beginning of the alphabet the rest of the alphabeth
-##  [57] the rest of the alphabeth beginning of the alphabet
-##  [59] the rest of the alphabeth beginning of the alphabet
-##  [61] the rest of the alphabeth beginning of the alphabet
-##  [63] the rest of the alphabeth beginning of the alphabet
-##  [65] beginning of the alphabet beginning of the alphabet
-##  [67] the rest of the alphabeth the rest of the alphabeth
-##  [69] the rest of the alphabeth the rest of the alphabeth
-##  [71] the rest of the alphabeth the rest of the alphabeth
-##  [73] beginning of the alphabet beginning of the alphabet
-##  [75] the rest of the alphabeth beginning of the alphabet
-##  [77] the rest of the alphabeth beginning of the alphabet
-##  [79] the rest of the alphabeth the rest of the alphabeth
-##  [81] beginning of the alphabet beginning of the alphabet
-##  [83] beginning of the alphabet beginning of the alphabet
-##  [85] beginning of the alphabet the rest of the alphabeth
-##  [87] beginning of the alphabet beginning of the alphabet
-##  [89] beginning of the alphabet beginning of the alphabet
-##  [91] beginning of the alphabet beginning of the alphabet
-##  [93] the rest of the alphabeth the rest of the alphabeth
-##  [95] the rest of the alphabeth beginning of the alphabet
-##  [97] beginning of the alphabet beginning of the alphabet
-##  [99] beginning of the alphabet beginning of the alphabet
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">some_letters &lt;-<span class="st"> </span><span class="kw">cfactor</span>(<span class="kw">sample</span>(letters, <span class="dv">100</span>, <span class="dt">replace =</span> <span class="ot">TRUE</span>), <span class="dt">ordered =</span> <span class="ot">TRUE</span>)
+<span class="kw">head</span>(<span class="kw">cut</span>(some_letters, <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;q&quot;</span>, <span class="st">&quot;z&quot;</span>), 
+         <span class="dt">labels =</span> <span class="kw">c</span>(<span class="st">&quot;beginning of the alphabet&quot;</span>, <span class="st">&quot;the rest of the alphabeth&quot;</span>), 
+         <span class="dt">right =</span> <span class="ot">TRUE</span>, <span class="dt">include.lowest =</span> <span class="ot">TRUE</span>))</code></pre></div>
+<pre><code>## [1] beginning of the alphabet the rest of the alphabeth
+## [3] the rest of the alphabeth beginning of the alphabet
+## [5] the rest of the alphabeth the rest of the alphabeth
 ## Levels: beginning of the alphabet the rest of the alphabeth</code></pre>
 </div>
 </div>

--- a/vignettes/refactor.html
+++ b/vignettes/refactor.html
@@ -12,7 +12,7 @@
 
 <meta name="author" content="Lorenz Walthert and Jon Calder" />
 
-<meta name="date" content="2016-09-19" />
+<meta name="date" content="2016-09-23" />
 
 <title>refactor</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">refactor</h1>
 <h4 class="author"><em>Lorenz Walthert and Jon Calder</em></h4>
-<h4 class="date"><em>2016-09-19</em></h4>
+<h4 class="date"><em>2016-09-23</em></h4>
 
 
 
@@ -89,8 +89,8 @@ upper &lt;-<span class="st"> </span><span class="kw">factor</span>(LETTERS[<span
 </ul>
 <p>The goal of the <code>refactor</code> package is to make working with factors more natural and fun by providing</p>
 <ul>
-<li>the wrapper <code>cfactor</code> for <code>factor</code> to enhance control at the point of factor creation</li>
-<li>a function <code>index_cfactor</code> to decode numerical data into (ordered) factors given the encoding</li>
+<li>the wrapper <code>cfactor</code> for <code>factor</code> to enhance control at the point of factor creation.</li>
+<li>a function <code>index_cfactor</code> to decode numerical data into (ordered) factors given the encoding.</li>
 <li>S3 generics for existing R base classes (mainly <code>ordered</code> and <code>factor</code>) where current methods are not tailored for categorical data.</li>
 </ul>
 </div>
@@ -117,24 +117,24 @@ string &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">
 <strong>A “clean” example</strong></p>
 <p>With all numbers having the same number of digits, <code>factor</code> can detect the order correctly.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">easy_to_dectect &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">&quot;EUR 11 - EUR 20&quot;</span>, <span class="st">&quot;EUR 1 - EUR 10&quot;</span>, <span class="st">&quot;EUR 21 - EUR 22&quot;</span>)
-<span class="kw">factor</span>(easy_to_dectect, <span class="dt">ordered =</span> T) <span class="co"># correctly detects level</span></code></pre></div>
+<span class="kw">factor</span>(easy_to_dectect, <span class="dt">ordered =</span> <span class="ot">TRUE</span>) <span class="co"># correctly detects level</span></code></pre></div>
 <pre><code>## [1] EUR 11 - EUR 20 EUR 1 - EUR 10  EUR 21 - EUR 22
 ## Levels: EUR 1 - EUR 10 &lt; EUR 11 - EUR 20 &lt; EUR 21 - EUR 22</code></pre>
 <p><br />
 <strong>A more “dirty” example</strong></p>
 <p>However, in the general case, where number of digits might be destinct, this does not work anymore. The category “EUR 100 - 101” comes second, but it should be last.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">hard_to_dectect &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">&quot;EUR 21 - EUR 22&quot;</span>, <span class="st">&quot;EUR 100 - 101&quot;</span>, <span class="st">&quot;EUR 1 - EUR 10&quot;</span>, <span class="st">&quot;EUR 11 - EUR 20&quot;</span>)
-<span class="kw">factor</span>(hard_to_dectect, <span class="dt">ordered =</span> T)</code></pre></div>
+<span class="kw">factor</span>(hard_to_dectect, <span class="dt">ordered =</span> <span class="ot">TRUE</span>)</code></pre></div>
 <pre><code>## [1] EUR 21 - EUR 22 EUR 100 - 101   EUR 1 - EUR 10  EUR 11 - EUR 20
 ## 4 Levels: EUR 1 - EUR 10 &lt; EUR 100 - 101 &lt; ... &lt; EUR 21 - EUR 22</code></pre>
 <p><code>cfactor</code> detects levels using regular expressions. Concretely, it extracts the substrings preceding <code>sep</code>, removes everything except digits and the decimal point in <code>x</code> and orders the remaining numbers to find the order of the levels.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cfactor</span>(hard_to_dectect, <span class="dt">ordered =</span> T, <span class="dt">sep =</span> <span class="st">&quot;-&quot;</span>)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cfactor</span>(hard_to_dectect, <span class="dt">ordered =</span> <span class="ot">TRUE</span>, <span class="dt">sep =</span> <span class="st">&quot;-&quot;</span>)</code></pre></div>
 <pre><code>## [1] EUR 21 - EUR 22 EUR 100 - 101   EUR 1 - EUR 10  EUR 11 - EUR 20
 ## 4 Levels: EUR 1 - EUR 10 &lt; EUR 11 - EUR 20 &lt; ... &lt; EUR 100 - 101</code></pre>
 <p>This detection algorithm can be turned off and the default ordering of <code>factor</code> can be applied by setting the <code>sep</code> argument to <code>NULL</code>. Also, in the absence of any numbers, the default ordering of <code>factor</code> is applied.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">identical</span>(
-  <span class="kw">cfactor</span>(hard_to_dectect, <span class="dt">ordered =</span> T, <span class="dt">sep =</span> <span class="ot">NULL</span>),
-   <span class="kw">factor</span>(hard_to_dectect, <span class="dt">ordered =</span> T)
+  <span class="kw">cfactor</span>(hard_to_dectect, <span class="dt">ordered =</span> <span class="ot">TRUE</span>, <span class="dt">sep =</span> <span class="ot">NULL</span>),
+   <span class="kw">factor</span>(hard_to_dectect, <span class="dt">ordered =</span> <span class="ot">TRUE</span>)
 )</code></pre></div>
 <pre><code>## [1] TRUE</code></pre>
 </div>
@@ -142,31 +142,29 @@ string &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">
 <div id="index_cfactor" class="section level2">
 <h2><code>index_cfactor</code></h2>
 <p>If data is encoded, the <code>labels</code> argument of <code>factor()</code> can be used to label the data, which is a common data pre-processing step. This works the same as with <code>cfactor()</code>. Here, we want to give an example where the relationship beteween the encoding and the label is stored in a <code>data.frame</code>, e.g. after it was imported from a spread sheet.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">data &lt;-<span class="st"> </span><span class="kw">sample</span>(<span class="dt">x =</span> <span class="dv">1</span>:<span class="dv">10</span>, <span class="dt">size =</span> <span class="dv">20</span>, <span class="dt">replace =</span> T)
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">data &lt;-<span class="st"> </span><span class="kw">sample</span>(<span class="dt">x =</span> <span class="dv">1</span>:<span class="dv">10</span>, <span class="dt">size =</span> <span class="dv">20</span>, <span class="dt">replace =</span> <span class="ot">TRUE</span>)
 index &lt;-<span class="st"> </span><span class="kw">data.frame</span>(<span class="dt">encoding =</span> <span class="dv">1</span>:<span class="dv">10</span>,
                     <span class="dt">label =</span> letters[<span class="dv">1</span>:<span class="dv">10</span>])
 
 <span class="kw">cfactor</span>(data, <span class="dt">levels =</span> index$encoding, <span class="dt">labels =</span> index$label)</code></pre></div>
-<pre><code>## Warning: the following levels were empty: 
-##  10</code></pre>
-<pre><code>##  [1] h b b e i g a a c i g g b f c b f a d f
+<pre><code>##  [1] h h d j h e h d i f g e h a b f c a j f
 ## Levels: a b c d e f g h i j</code></pre>
 <p><br />
 In a real-world situation, it is likely that a lot of variables have to be decoded. <code>index_cfactor</code> was created to assist with this task. First, we need some sample data.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">data &lt;-<span class="st"> </span><span class="kw">data.frame</span>(<span class="dt">var1 =</span> <span class="kw">sample</span>(<span class="dt">x =</span> <span class="dv">1</span>:<span class="dv">10</span>, <span class="dt">size =</span> <span class="dv">20</span>, <span class="dt">replace =</span> T),
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">data &lt;-<span class="st"> </span><span class="kw">data.frame</span>(<span class="dt">var1 =</span> <span class="kw">sample</span>(<span class="dt">x =</span> <span class="dv">1</span>:<span class="dv">10</span>, <span class="dt">size =</span> <span class="dv">20</span>, <span class="dt">replace =</span> <span class="ot">TRUE</span>),
                   <span class="dt">var2 =</span> <span class="kw">rep</span>(<span class="dv">1</span>:<span class="dv">2</span>, <span class="dv">20</span>),
                   <span class="dt">var3 =</span> <span class="kw">sample</span>(<span class="dv">20</span>),
                   <span class="dt">var4 =</span> <span class="dv">2</span>, 
                   <span class="dt">var5 =</span> <span class="kw">sample</span>(<span class="kw">row.names</span>(USArrests), <span class="dt">size =</span> <span class="dv">20</span>),
-                  <span class="dt">stringsAsFactors =</span> F)
+                  <span class="dt">stringsAsFactors =</span> <span class="ot">FALSE</span>)
 <span class="kw">head</span>(data)</code></pre></div>
-<pre><code>##   var1 var2 var3 var4       var5
-## 1    6    1    3    2 California
-## 2    9    2   15    2   New York
-## 3    4    1    6    2   Nebraska
-## 4    2    2   10    2     Alaska
-## 5    2    1   12    2      Maine
-## 6    5    2    9    2   Michigan</code></pre>
+<pre><code>##   var1 var2 var3 var4          var5
+## 1    7    1    9    2       Alabama
+## 2    8    2    8    2     Tennessee
+## 3    8    1   18    2      Delaware
+## 4    6    2   10    2    New Jersey
+## 5    9    1    4    2      Oklahoma
+## 6    3    2   17    2 New Hampshire</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">index &lt;-<span class="st"> </span><span class="kw">data.frame</span>(<span class="dt">var =</span> <span class="kw">rep</span>(<span class="kw">paste0</span>(<span class="st">&quot;var&quot;</span>, <span class="dv">1</span>:<span class="dv">3</span>), <span class="kw">c</span>(<span class="dv">10</span>, <span class="dv">2</span>, <span class="dv">20</span>)),
                     <span class="dt">encoding =</span> <span class="kw">c</span>(<span class="dv">1</span>:<span class="dv">10</span>, <span class="dv">1</span>:<span class="dv">2</span>, <span class="dv">1</span>:<span class="dv">20</span>),
                     <span class="dt">label =</span> <span class="kw">c</span>(letters[<span class="dv">1</span>:<span class="dv">10</span>], <span class="kw">c</span>(<span class="st">&quot;male&quot;</span>, <span class="st">&quot;female&quot;</span>), LETTERS[<span class="dv">1</span>:<span class="dv">20</span>]))
@@ -179,15 +177,17 @@ In a real-world situation, it is likely that a lot of variables have to be decod
 ## 5 var1        5     e
 ## 6 var1        6     f</code></pre>
 <p>Now we use <code>index_cfactor</code> to decode the <code>data.frame</code>. Note that <code>var4</code> and <code>var5</code> are left as is, since no variable encoding for them is defined in <code>index</code>. Using the <code>...</code> argument of <code>index_cfactor</code>, we can pass additional arguments to <code>cfactor</code>.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">final &lt;-<span class="st"> </span><span class="kw">head</span>(<span class="kw">index_cfactor</span>(<span class="dt">data =</span> data, <span class="dt">index =</span> index, <span class="dt">variable =</span> <span class="st">&quot;var&quot;</span>, <span class="dt">ordered =</span> <span class="kw">c</span>(<span class="ot">TRUE</span>, <span class="ot">TRUE</span>, <span class="ot">FALSE</span>)))
-<span class="kw">print</span>(final)</code></pre></div>
-<pre><code>##   var1   var2 var3 var4       var5
-## 1    f   male    C    2 California
-## 2    i female    O    2   New York
-## 3    d   male    F    2   Nebraska
-## 4    b female    J    2     Alaska
-## 5    b   male    L    2      Maine
-## 6    e female    I    2   Michigan</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">final &lt;-<span class="st"> </span><span class="kw">head</span>(<span class="kw">index_cfactor</span>(<span class="dt">data =</span> data, <span class="dt">index =</span> index, <span class="dt">variable =</span> <span class="st">&quot;var&quot;</span>, <span class="dt">ordered =</span> <span class="kw">c</span>(<span class="ot">TRUE</span>, <span class="ot">TRUE</span>, <span class="ot">FALSE</span>)))</code></pre></div>
+<pre><code>## Warning: the following levels were empty: 
+##  10</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">print</span>(final)</code></pre></div>
+<pre><code>##   var1   var2 var3 var4          var5
+## 1    g   male    I    2       Alabama
+## 2    h female    H    2     Tennessee
+## 3    h   male    R    2      Delaware
+## 4    f female    J    2    New Jersey
+## 5    i   male    D    2      Oklahoma
+## 6    c female    Q    2 New Hampshire</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">sapply</span>(final, class)</code></pre></div>
 <pre><code>## $var1
 ## [1] &quot;ordered&quot; &quot;factor&quot; 
@@ -222,52 +222,99 @@ In a real-world situation, it is likely that a lot of variables have to be decod
 <p><code>cut.default</code> provides rather inappropriate labels for integer values.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">random &lt;-<span class="st"> </span><span class="kw">sample</span>(<span class="dv">100</span>)
 <span class="kw">cut.default</span>(random, <span class="dt">breaks =</span> <span class="kw">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dt">by =</span> <span class="dv">10</span>))[<span class="dv">1</span>:<span class="dv">10</span>]</code></pre></div>
-<pre><code>##  [1] (90,100] (20,30]  (90,100] (30,40]  (80,90]  (70,80]  (80,90] 
-##  [8] (20,30]  (40,50]  (60,70] 
+<pre><code>##  [1] (80,90]  (60,70]  (0,10]   (10,20]  (0,10]   (30,40]  (70,80] 
+##  [8] (90,100] (90,100] (10,20] 
 ## 10 Levels: (0,10] (10,20] (20,30] (30,40] (40,50] (50,60] ... (90,100]</code></pre>
 <p><code>refactor</code> extends the S3 method <code>cut</code> with <code>cut.integer</code> to provide more natural labels for this data type.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(random, <span class="dt">breaks =</span> <span class="kw">seq</span>(<span class="dv">0</span>, <span class="dv">100</span>, <span class="dt">by =</span> <span class="dv">10</span>))[<span class="dv">1</span>:<span class="dv">10</span>]</code></pre></div>
-<pre><code>##  [1] 91-100 21-30  91-100 31-40  81-90  71-80  81-90  21-30  41-50  61-70 
+<pre><code>##  [1] 81-90  61-70  0-10   11-20  0-10   31-40  71-80  91-100 91-100 11-20 
 ## Levels: 0-10 11-20 21-30 31-40 41-50 51-60 61-70 71-80 81-90 91-100</code></pre>
 <p>The remainder of the section will outline and describe how <code>cut.integer</code> deviates from the default <code>cut</code> method.<br />
 <br><br> Creating missing values will yield a warning.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">0</span>, <span class="dv">3</span>, <span class="dv">5</span>))</code></pre></div>
 <pre><code>## Warning in cut.integer(sample(10), breaks = c(0, 3, 5)): 5 missing values
 ## generated</code></pre>
-<pre><code>##  [1] 0-3  &lt;NA&gt; &lt;NA&gt; &lt;NA&gt; &lt;NA&gt; 4-5  &lt;NA&gt; 4-5  0-3  0-3 
+<pre><code>##  [1] &lt;NA&gt; &lt;NA&gt; &lt;NA&gt; 4-5  &lt;NA&gt; 0-3  0-3  4-5  &lt;NA&gt; 0-3 
 ## Levels: 0-3 4-5</code></pre>
 <p>It is possible to define bins with width 1. This will generate a label with just the value of the integer containted (e.g. 2 instead of 2-2) and issue a warning.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">1</span>, <span class="dv">4</span>, <span class="dv">6</span>, <span class="dv">8</span>, <span class="dv">9</span>, <span class="dv">10</span>))</code></pre></div>
 <pre><code>## Warning in cut.integer(sample(10), breaks = c(1, 4, 6, 8, 9, 10)): this
 ## break specification produces 2 bin(s) of width 1. The corresponding
 ## label(s) are: 9, 10</code></pre>
-<pre><code>##  [1] 9   5-6 10  1-4 1-4 5-6 7-8 7-8 1-4 1-4
+<pre><code>##  [1] 7-8 5-6 9   1-4 5-6 1-4 1-4 10  7-8 1-4
 ## Levels: 1-4 5-6 7-8 9 10</code></pre>
 <p>Unordered breaks will be ordered before proceeding and a warning will be issued.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">10</span>, <span class="dv">0</span>, <span class="dv">3</span>))</code></pre></div>
 <pre><code>## Warning in cut.integer(sample(10), breaks = c(10, 0, 3)): breaks were
 ## unsorted and are now sorted in the following order: 0 3 10</code></pre>
-<pre><code>##  [1] 0-3  4-10 4-10 4-10 0-3  4-10 0-3  4-10 4-10 4-10
+<pre><code>##  [1] 4-10 4-10 0-3  4-10 0-3  4-10 4-10 0-3  4-10 4-10
 ## Levels: 0-3 4-10</code></pre>
 <p>Decimal values for <code>breaks</code> will be rounded to integers and a warning will be issued.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">cut</span>(<span class="kw">sample</span>(<span class="dv">10</span>), <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="dv">1</span>, <span class="fl">2.6</span>, <span class="fl">5.1</span>, <span class="dv">10</span>))</code></pre></div>
-<pre><code>## Warning in cut.integer(sample(10), breaks = c(1, 2.6, 5.1, 10)): When coerced to integers, the following breaks were rounded: 
-##   2.6 to 3  
+<pre><code>## Warning in cut.integer(sample(10), breaks = c(1, 2.6, 5.1, 10)): When coerced to integers, the following breaks were truncated (rounded down): 
+##   2.6 to 2  
 ##   5.1 to 5  
 ## </code></pre>
-<pre><code>##  [1] 6-10 6-10 6-10 4-5  1-3  1-3  1-3  6-10 6-10 4-5 
-## Levels: 1-3 4-5 6-10</code></pre>
+<pre><code>##  [1] 1-2  6-10 6-10 3-5  3-5  6-10 3-5  6-10 1-2  6-10
+## Levels: 1-2 3-5 6-10</code></pre>
 </div>
 <div id="a-cut-method-for-ordered-factors" class="section level4">
 <h4>a <code>cut</code> method for ordered factors</h4>
 <p>This method allows one to combine the levels of a factor into fewer categories given some break points:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(refactor)
-timeX &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">&quot;very low&quot;</span>, <span class="st">&quot;rather low&quot;</span>, <span class="st">&quot;low&quot;</span>, <span class="st">&quot;medium&quot;</span>, <span class="st">&quot;upper medium&quot;</span>, <span class="st">&quot;high&quot;</span>)
-time &lt;-<span class="st"> </span><span class="kw">factor</span>(timeX, <span class="dt">levels =</span> <span class="kw">unique</span>(timeX), <span class="dt">ordered =</span> T)
-
-<span class="kw">cut</span>(time, <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="st">&quot;low&quot;</span>, <span class="st">&quot;medium&quot;</span>, <span class="st">&quot;high&quot;</span>))</code></pre></div>
-<pre><code>## [1] low    low    low    medium high   high  
-## Levels: low medium high</code></pre>
+some_letters &lt;-<span class="st"> </span><span class="kw">cfactor</span>(<span class="kw">sample</span>(letters, <span class="dv">100</span>, <span class="dt">replace =</span> <span class="ot">TRUE</span>), <span class="dt">ordered =</span> <span class="ot">TRUE</span>)
+<span class="kw">cut</span>(some_letters, <span class="dt">breaks =</span> <span class="kw">c</span>(<span class="st">&quot;a&quot;</span>, <span class="st">&quot;q&quot;</span>, <span class="st">&quot;z&quot;</span>), <span class="dt">labels =</span> <span class="kw">c</span>(<span class="st">&quot;beginning of the alphabet&quot;</span>, <span class="st">&quot;the rest of the alphabeth&quot;</span>), <span class="dt">right =</span> <span class="ot">TRUE</span>, <span class="dt">include.lowest =</span> <span class="ot">TRUE</span>)</code></pre></div>
+<pre><code>##   [1] the rest of the alphabeth beginning of the alphabet
+##   [3] beginning of the alphabet the rest of the alphabeth
+##   [5] beginning of the alphabet beginning of the alphabet
+##   [7] the rest of the alphabeth the rest of the alphabeth
+##   [9] beginning of the alphabet the rest of the alphabeth
+##  [11] the rest of the alphabeth beginning of the alphabet
+##  [13] beginning of the alphabet the rest of the alphabeth
+##  [15] beginning of the alphabet the rest of the alphabeth
+##  [17] beginning of the alphabet beginning of the alphabet
+##  [19] beginning of the alphabet the rest of the alphabeth
+##  [21] the rest of the alphabeth beginning of the alphabet
+##  [23] beginning of the alphabet beginning of the alphabet
+##  [25] beginning of the alphabet the rest of the alphabeth
+##  [27] beginning of the alphabet the rest of the alphabeth
+##  [29] beginning of the alphabet beginning of the alphabet
+##  [31] beginning of the alphabet beginning of the alphabet
+##  [33] beginning of the alphabet beginning of the alphabet
+##  [35] the rest of the alphabeth beginning of the alphabet
+##  [37] beginning of the alphabet the rest of the alphabeth
+##  [39] beginning of the alphabet beginning of the alphabet
+##  [41] beginning of the alphabet beginning of the alphabet
+##  [43] beginning of the alphabet the rest of the alphabeth
+##  [45] the rest of the alphabeth beginning of the alphabet
+##  [47] the rest of the alphabeth beginning of the alphabet
+##  [49] beginning of the alphabet the rest of the alphabeth
+##  [51] beginning of the alphabet the rest of the alphabeth
+##  [53] beginning of the alphabet the rest of the alphabeth
+##  [55] beginning of the alphabet the rest of the alphabeth
+##  [57] the rest of the alphabeth beginning of the alphabet
+##  [59] the rest of the alphabeth beginning of the alphabet
+##  [61] the rest of the alphabeth beginning of the alphabet
+##  [63] the rest of the alphabeth beginning of the alphabet
+##  [65] beginning of the alphabet beginning of the alphabet
+##  [67] the rest of the alphabeth the rest of the alphabeth
+##  [69] the rest of the alphabeth the rest of the alphabeth
+##  [71] the rest of the alphabeth the rest of the alphabeth
+##  [73] beginning of the alphabet beginning of the alphabet
+##  [75] the rest of the alphabeth beginning of the alphabet
+##  [77] the rest of the alphabeth beginning of the alphabet
+##  [79] the rest of the alphabeth the rest of the alphabeth
+##  [81] beginning of the alphabet beginning of the alphabet
+##  [83] beginning of the alphabet beginning of the alphabet
+##  [85] beginning of the alphabet the rest of the alphabeth
+##  [87] beginning of the alphabet beginning of the alphabet
+##  [89] beginning of the alphabet beginning of the alphabet
+##  [91] beginning of the alphabet beginning of the alphabet
+##  [93] the rest of the alphabeth the rest of the alphabeth
+##  [95] the rest of the alphabeth beginning of the alphabet
+##  [97] beginning of the alphabet beginning of the alphabet
+##  [99] beginning of the alphabet beginning of the alphabet
+## Levels: beginning of the alphabet the rest of the alphabeth</code></pre>
 </div>
 </div>
 </div>


### PR DESCRIPTION
This pull request aims to merge latest developments in the package with master to the version `0.1.0.9001`. The major differences to the current master `0.1.0.9001` are: 
- updated documentation: Add missing arguments, spelling, formatting. Adding details how package methods deviate from base methods.
- improved performance of `R CMD check`: eliminated warnings. Previous: NO ERRORs, 2 WARNINGs, 1 NOTE. 
- style: All lines of code are now (roughly) 80 characters long, `T` and `F` turned into explicit notation `TRUE` AND `FALSE`.
- `cut.integer`: `floor` is used rather than `round` when breaks are supplied as decimal numbers. The quantile method was dropped.
- `index_cfactor`: arguments only recycled if length 1 (Previously if full recycling was possible).
