### PR TITLE
Breaks mode

### DIFF
--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -6,7 +6,9 @@
 #' @param x A numeric vector which is to be converted to a factor by cutting.
 #' @param breaks Either an integer vector of two or more unique cut points or a
 #'   single integer (greater than or equal to 2) giving the number of intervals
-#'   into which \code{x} is to be cut.
+#'   into which \code{x} is to be cut. Please note, however, that the resulting 
+#'   number of intervals is not guaranteed to be x in the case of 
+#'   breaks_mode = "pretty".
 #' @param labels Labels for the levels of the resulting category. By default,
 #'   labels are constructed using "a-b c-d" interval notation. If 
 #'   \code{labels = FALSE}, simple integer codes are returned instead of a 
@@ -27,7 +29,8 @@
 #'   for details.
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @param breaks_mode A parameter indicating how to determine the intervals 
-#'  when breaks is specified as a scalar. 
+#'  when breaks is specified as a scalar (note that this argument has no effect 
+#'  if breaks is specified as a vector).
 #'  \itemize{ 
 #'    \item 'default' will produce intervals which are the (integer) equivalent 
 #'    to those produced by cut.default i.e. the bins/groupings will be the 
@@ -37,9 +40,10 @@
 #'    over the exact range of \code{x}. If the intervals cannot all be equal, 
 #'    then \code{right} determines whether the rightmost (TRUE) or leftmost 
 #'    (FALSE) intervals are made slightly wider.
-#'    \item 'pretty' will generate rounded breakpoints for the intervals (often
-#'    extending slightly beyond the range of \code{x}) based on 
-#'    \link[base]{pretty}.}
+#'    \item 'pretty' will generate rounded breakpoints for the intervals based 
+#'    on \link[base]{pretty}. Note that breaks here is treated as the 'desired' 
+#'    number of intervals and is not guaranteed. Note also that the range of 
+#'    \code{x}) can be exceeded slightly by the intervals in some cases.}
 #' @param label_sep A single or short character string used to generate labels
 #'   for the intervals e.g. the default value of "-" will result in labels like
 #'   1-10 11-20 21-30 etc.

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -138,8 +138,6 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
   # create breakpoints based on breaks_mode
   if(length(breaks) == 1){
     
-    numLabels <- breaks
-    
     # should breakpoints be the (integer) equivalent of cut.default?
     if(breaks_mode == "default"){
       
@@ -172,11 +170,10 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
   } else if(length(breaks > 1)){
     
     breakpoints <- breaks
-
-    numLabels <- length(breakpoints) - 1
     
   }
 
+  numLabels <- length(breakpoints) - 1
   
 ############################## breakpoints completed ###########################
 

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -25,7 +25,7 @@
 #'   vice versa (i.e. as in \code{\link[base]{cut.default}}). If a 
 #'   single integer breaks value is provided, then the appropriate breakpoints 
 #'   are determined based on the value of \code{breaks_mode}, and the value for 
-#'   \code{right} is only utilized if \code{breaks_mode = 'spread'} - see below 
+#'   \code{right} is not utilized if \code{breaks_mode = 'pretty'} - see below 
 #'   for details.
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @param breaks_mode A parameter indicating how to determine the intervals 

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -150,6 +150,7 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
       nb <- as.integer(breaks + 1) # one more than #{intervals}
       dx <- diff(rx <- range(x, na.rm = TRUE))
       breakpoints <- floor(seq.int(rx[1L], rx[2L], length.out = nb))
+      include.lowest = TRUE
       
     # or "spread" over the range of the data?
     } else if(breaks_mode == "spread"){
@@ -168,8 +169,13 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
     # Now that the breakpoints have been determined, set right = TRUE since this 
     # is (by convention) the required interpretation of these breakpoints for 
     # the purpose of the labeling which follows
-    right <- TRUE
+    # However the default method needs to honor the right argument in order to 
+    # keep consistency with cut.default
+    if(breaks_mode != "default"){
     
+        right <- TRUE
+        
+    }
     
   # use breakpoints as is if provided  
   } else if(length(breaks > 1)){

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -76,7 +76,7 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
   assert_class(include.lowest, "logical")
   assert_class(right, "logical")
   assert_class(ordered_result, "logical")
-  assert_choice(breaks_mode, c("default", "pretty"))
+  assert_choice(breaks_mode, c("default", "spread", "pretty"))
   assert_class(label_sep, "character")
   
   # NAs in breaks
@@ -128,22 +128,30 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
 ############################## determine breakpoints ###########################
     
   # if breaks are not specified (i.e. only the number of breaks is provided)
+  # create breakpoints based on breaks_mode
   if(length(breaks) == 1){
     
     numLabels <- breaks
     
-    # create breakpoints based on breaks_mode
-    # should the breaks be "pretty"? (‘round’ values which cover the range of x)
-    # or evenly spaced over the range of the data? ("default")
-    if(breaks_mode == "pretty"){
+    # should breakpoints be the (integer) equivalent of cut.default?
+    if(breaks_mode == "default"){
       
-      breakpoints <- pretty(x, breaks)
+      # adapted from base::cut.default
+      nb <- as.integer(breaks + 1) # one more than #{intervals}
+      dx <- diff(rx <- range(x, na.rm = TRUE))
+      breakpoints <- floor(seq.int(rx[1L], rx[2L], length.out = nb))
       
-    } else if(breaks_mode == "default"){
+    # or "spread" over the range of the data?
+    } else if(breaks_mode == "spread"){
       
       breaks_output <- cut_breakpoints(x, breaks, right, include.lowest)
       breakpoints <- breaks_output$breakpoints
       include.lowest <- breaks_output$include.lowest
+    
+    # or "pretty"? (‘round’ values which cover the range of x)
+    } else if (breaks_mode == "pretty"){
+      
+      breakpoints <- pretty(x, breaks)
       
     }
     
@@ -190,7 +198,7 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
     }
 
     
-  } else if(!is.null(labels)) {
+  } else {
     
     recode_labels <- labels
     

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -7,7 +7,7 @@
 #' @param breaks Either an integer vector of two or more unique cut points or a
 #'   single integer (greater than or equal to 2) giving the number of intervals
 #'   into which \code{x} is to be cut. Please note, however, that the resulting 
-#'   number of intervals is not guaranteed to be x in the case of 
+#'   number of intervals is not guaranteed to be \code{breaks} in the case of 
 #'   breaks_mode = "pretty".
 #' @param labels Labels for the levels of the resulting category. By default,
 #'   labels are constructed using "a-b c-d" interval notation. If 
@@ -38,12 +38,13 @@
 #'    (numeric, numeric]/(1.5,4.2].
 #'    \item 'spread' will result in intervals spread as evenly as possible 
 #'    over the exact range of \code{x}. If the intervals cannot all be equal, 
-#'    then \code{right} determines whether the rightmost (TRUE) or leftmost 
-#'    (FALSE) intervals are made slightly wider.
+#'    then \code{right} determines whether the rightmost (\code{TRUE}) or 
+#'    leftmost (\code{FALSE}) intervals are made slightly wider.
 #'    \item 'pretty' will generate rounded breakpoints for the intervals based 
-#'    on \link[base]{pretty}. Note that breaks here is treated as the 'desired' 
-#'    number of intervals and is not guaranteed. Note also that the range of 
-#'    \code{x}) can be exceeded slightly by the intervals in some cases.}
+#'    on \code{\link[base]{pretty}}. Note that breaks here is treated as the 
+#'    'desired' number of intervals and is not guaranteed. Note also that the 
+#'    range of \code{x} can be exceeded slightly by the intervals in some 
+#'    cases.}
 #' @param label_sep A single or short character string used to generate labels
 #'   for the intervals e.g. the default value of "-" will result in labels like
 #'   1-10 11-20 21-30 etc.

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -8,7 +8,7 @@
 #'   single integer (greater than or equal to 2) giving the number of intervals
 #'   into which \code{x} is to be cut. Please note, however, that the resulting 
 #'   number of intervals is not guaranteed to be \code{breaks} in the case of 
-#'   breaks_mode = "pretty".
+#'   \code{breaks_mode = 'pretty'}.
 #' @param labels Labels for the levels of the resulting category. By default,
 #'   labels are constructed using "a-b c-d" interval notation. If 
 #'   \code{labels = FALSE}, simple integer codes are returned instead of a 
@@ -30,10 +30,24 @@
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @param breaks_mode A parameter indicating how to determine the intervals 
 #'  when breaks is specified as a scalar (note that this argument has no effect 
-#'  if breaks is specified as a vector).
+#'  if breaks is specified as a vector). Can be 'default', 'spread' or 
+#'  'pretty'. See 'Details' below.
+#' @param label_sep A single or short character string used to generate labels
+#'   for the intervals e.g. the default value of "-" will result in labels like
+#'   1-10 11-20 21-30 etc.
+#' @param ... Further arguments to be passed to or from other methods, 
+#'  in particular to \code{\link{cut.default}}.
+#' @details In deviation from \code{cut.default}, \code{cut.integer} does not 
+#'  have an argument \code{dig.lab}, but instead has two arguments that do not 
+#'  exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}. \cr
+#'  Note that unlike \code{\link[base]{cut.default}}, here 
+#'  \code{include.lowest} defaults to \code{TRUE}, since this is more intuitive 
+#'  for the class \code{integer}. \cr
+#'  If \code{breaks} is supplied as a scalar, the value of \code{breaks_mode} determines 
+#'  how the breaks are constructed:
 #'  \itemize{ 
 #'    \item 'default' will produce intervals which are the (integer) equivalent 
-#'    to those produced by cut.default i.e. the bins/groupings will be the 
+#'    to those produced by \code{cut.default} i.e. the bins/groupings will be the 
 #'    same - but the labels will be of the form int-int/2-4 instead of 
 #'    (numeric, numeric]/(1.5,4.2].
 #'    \item 'spread' will result in intervals spread as evenly as possible 
@@ -45,17 +59,7 @@
 #'    'desired' number of intervals and is not guaranteed. Note also that the 
 #'    range of \code{x} can be exceeded slightly by the intervals in some 
 #'    cases.}
-#' @param label_sep A single or short character string used to generate labels
-#'   for the intervals e.g. the default value of "-" will result in labels like
-#'   1-10 11-20 21-30 etc.
-#' @param ... Further arguments to be passed to or from other methods, 
-#'  in particular to \code{\link{cut.default}}.
-#' @details In deviation from \code{cut.default}, \code{cut.integer} does not 
-#'  have an argument \code{dig.lab}, but instead has two arguments that do not 
-#'  exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
-#'  Note that unlike \code{\link[base]{cut.default}}, here 
-#'  \code{include.lowest} defaults to \code{TRUE}, since this is more intuitive 
-#'  for the class \code{integer}.
+
 #' @return A factor is returned, unless \code{labels = FALSE} which results in 
 #' an integer vector of level codes.
 #' @examples 

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -160,7 +160,7 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
         breakpoints <- ceiling(seq.int(rx[1L], rx[2L], length.out = nb))
       }
         
-      include.lowest = TRUE
+      include.lowest <- TRUE
       
     # or "spread" over the range of the data?
     } else if(breaks_mode == "spread"){

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -153,7 +153,13 @@ cut.integer <- function(x, breaks, labels = NULL, include.lowest = TRUE,
       # adapted from base::cut.default
       nb <- as.integer(breaks + 1) # one more than #{intervals}
       dx <- diff(rx <- range(x, na.rm = TRUE))
-      breakpoints <- floor(seq.int(rx[1L], rx[2L], length.out = nb))
+      
+      if(right == TRUE) {
+        breakpoints <- floor(seq.int(rx[1L], rx[2L], length.out = nb))  
+      } else {
+        breakpoints <- ceiling(seq.int(rx[1L], rx[2L], length.out = nb))
+      }
+        
       include.lowest = TRUE
       
     # or "spread" over the range of the data?

--- a/R/cut.integer.R
+++ b/R/cut.integer.R
@@ -16,20 +16,27 @@
 #'   Note that unlike \code{\link[base]{cut.default}}, here 
 #'   \code{include.lowest} defaults to \code{TRUE}, since this is more 
 #'   intuitive for integer intervals.
-#' @param right	Logical, indicating how to create the bins. This is utilized in
-#'   two different ways based on the type of breaks argument. In the
-#'   conventional case, where a breaks vector is supplied, \code{right = TRUE}
+#' @param right	Logical, indicating how to create the bins. This is utilized in 
+#'   different ways based on the type of breaks argument. In the conventional 
+#'   case, where a breaks vector is supplied, \code{right = TRUE}
 #'   indicates that bins should be closed on the right (and open on the left) or
-#'   vice versa. If a single integer breaks value is provided, then 
-#'   \code{right = TRUE} indicates that bins will be determined such that those 
-#'   on the right are larger (if it is not possible for all bins to be evenly 
-#'   sized).
+#'   vice versa (i.e. as in \code{\link[base]{cut.default}}). If a 
+#'   single integer breaks value is provided, then the appropriate breakpoints 
+#'   are determined based on the value of \code{breaks_mode}, and the value for 
+#'   \code{right} is only utilized if \code{breaks_mode = 'spread'} - see below 
+#'   for details.
 #' @param ordered_result Logical: should the result be an ordered factor?
 #' @param breaks_mode A parameter indicating how to determine the intervals 
 #'  when breaks is specified as a scalar. 
 #'  \itemize{ 
-#'    \item 'default' will result in intervals spread as evenly as possible 
-#'    over the exact range of \code{x}. 
+#'    \item 'default' will produce intervals which are the (integer) equivalent 
+#'    to those produced by cut.default i.e. the bins/groupings will be the 
+#'    same - but the labels will be of the form int-int/2-4 instead of 
+#'    (numeric, numeric]/(1.5,4.2].
+#'    \item 'spread' will result in intervals spread as evenly as possible 
+#'    over the exact range of \code{x}. If the intervals cannot all be equal, 
+#'    then \code{right} determines whether the rightmost (TRUE) or leftmost 
+#'    (FALSE) intervals are made slightly wider.
 #'    \item 'pretty' will generate rounded breakpoints for the intervals (often
 #'    extending slightly beyond the range of \code{x}) based on 
 #'    \link[base]{pretty}.}

--- a/R/cut_helper.R
+++ b/R/cut_helper.R
@@ -4,20 +4,8 @@
 
 cut_breakpoints <- function(x, breaks, right, include.lowest){
 
-############################## assertive checks ################################
-
-  assert(
-    test_class(x, "numeric"),
-    test_class(x, "integer")
-  )
-  assert(
-    test_class(breaks, "numeric"),
-    test_class(breaks, "integer")
-  )
-  assert_class(right, "logical")
-  assert_class(include.lowest, "logical")
-  
-############################## assertive checks completed ######################
+# assertive checks not necessary since this function should only ever be called 
+# internally after inputs have already been checked
   
   range <- max(x)-min(x)+1
   avg_bin_width <- floor(range/breaks)

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -26,22 +26,29 @@ Note that unlike \code{\link[base]{cut.default}}, here
 \code{include.lowest} defaults to \code{TRUE}, since this is more 
 intuitive for integer intervals.}
 
-\item{right}{Logical, indicating how to create the bins. This is utilized in
-two different ways based on the type of breaks argument. In the
-conventional case, where a breaks vector is supplied, \code{right = TRUE}
+\item{right}{Logical, indicating how to create the bins. This is utilized in 
+different ways based on the type of breaks argument. In the conventional 
+case, where a breaks vector is supplied, \code{right = TRUE}
 indicates that bins should be closed on the right (and open on the left) or
-vice versa. If a single integer breaks value is provided, then 
-\code{right = TRUE} indicates that bins will be determined such that those 
-on the right are larger (if it is not possible for all bins to be evenly 
-sized).}
+vice versa (i.e. as in \code{\link[base]{cut.default}}). If a 
+single integer breaks value is provided, then the appropriate breakpoints 
+are determined based on the value of \code{breaks_mode}, and the value for 
+\code{right} is only utilized if \code{breaks_mode = 'spread'} - see below 
+for details.}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
 \item{breaks_mode}{A parameter indicating how to determine the intervals 
 when breaks is specified as a scalar. 
 \itemize{ 
-  \item 'default' will result in intervals spread as evenly as possible 
-  over the exact range of \code{x}. 
+  \item 'default' will produce intervals which are the (integer) equivalent 
+  to those produced by cut.default i.e. the bins/groupings will be the 
+  same - but the labels will be of the form int-int/2-4 instead of 
+  (numeric, numeric]/(1.5,4.2].
+  \item 'spread' will result in intervals spread as evenly as possible 
+  over the exact range of \code{x}. If the intervals cannot all be equal, 
+  then \code{right} determines whether the rightmost (TRUE) or leftmost 
+  (FALSE) intervals are made slightly wider.
   \item 'pretty' will generate rounded breakpoints for the intervals (often
   extending slightly beyond the range of \code{x}) based on 
   \link[base]{pretty}.}}

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -13,7 +13,9 @@
 
 \item{breaks}{Either an integer vector of two or more unique cut points or a
 single integer (greater than or equal to 2) giving the number of intervals
-into which \code{x} is to be cut.}
+into which \code{x} is to be cut. Please note, however, that the resulting 
+number of intervals is not guaranteed to be x in the case of 
+breaks_mode = "pretty".}
 
 \item{labels}{Labels for the levels of the resulting category. By default,
 labels are constructed using "a-b c-d" interval notation. If 
@@ -39,7 +41,8 @@ for details.}
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
 \item{breaks_mode}{A parameter indicating how to determine the intervals 
-when breaks is specified as a scalar. 
+when breaks is specified as a scalar (note that this argument has no effect 
+if breaks is specified as a vector).
 \itemize{ 
   \item 'default' will produce intervals which are the (integer) equivalent 
   to those produced by cut.default i.e. the bins/groupings will be the 
@@ -49,9 +52,10 @@ when breaks is specified as a scalar.
   over the exact range of \code{x}. If the intervals cannot all be equal, 
   then \code{right} determines whether the rightmost (TRUE) or leftmost 
   (FALSE) intervals are made slightly wider.
-  \item 'pretty' will generate rounded breakpoints for the intervals (often
-  extending slightly beyond the range of \code{x}) based on 
-  \link[base]{pretty}.}}
+  \item 'pretty' will generate rounded breakpoints for the intervals based 
+  on \link[base]{pretty}. Note that breaks here is treated as the 'desired' 
+  number of intervals and is not guaranteed. Note also that the range of 
+  \code{x}) can be exceeded slightly by the intervals in some cases.}}
 
 \item{label_sep}{A single or short character string used to generate labels
 for the intervals e.g. the default value of "-" will result in labels like

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -14,7 +14,7 @@
 \item{breaks}{Either an integer vector of two or more unique cut points or a
 single integer (greater than or equal to 2) giving the number of intervals
 into which \code{x} is to be cut. Please note, however, that the resulting 
-number of intervals is not guaranteed to be x in the case of 
+number of intervals is not guaranteed to be \code{breaks} in the case of 
 breaks_mode = "pretty".}
 
 \item{labels}{Labels for the levels of the resulting category. By default,
@@ -50,12 +50,13 @@ if breaks is specified as a vector).
   (numeric, numeric]/(1.5,4.2].
   \item 'spread' will result in intervals spread as evenly as possible 
   over the exact range of \code{x}. If the intervals cannot all be equal, 
-  then \code{right} determines whether the rightmost (TRUE) or leftmost 
-  (FALSE) intervals are made slightly wider.
+  then \code{right} determines whether the rightmost (\code{TRUE}) or 
+  leftmost (\code{FALSE}) intervals are made slightly wider.
   \item 'pretty' will generate rounded breakpoints for the intervals based 
-  on \link[base]{pretty}. Note that breaks here is treated as the 'desired' 
-  number of intervals and is not guaranteed. Note also that the range of 
-  \code{x}) can be exceeded slightly by the intervals in some cases.}}
+  on \code{\link[base]{pretty}}. Note that breaks here is treated as the 
+  'desired' number of intervals and is not guaranteed. Note also that the 
+  range of \code{x} can be exceeded slightly by the intervals in some 
+  cases.}}
 
 \item{label_sep}{A single or short character string used to generate labels
 for the intervals e.g. the default value of "-" will result in labels like

--- a/man/cut.integer.Rd
+++ b/man/cut.integer.Rd
@@ -15,7 +15,7 @@
 single integer (greater than or equal to 2) giving the number of intervals
 into which \code{x} is to be cut. Please note, however, that the resulting 
 number of intervals is not guaranteed to be \code{breaks} in the case of 
-breaks_mode = "pretty".}
+\code{breaks_mode = 'pretty'}.}
 
 \item{labels}{Labels for the levels of the resulting category. By default,
 labels are constructed using "a-b c-d" interval notation. If 
@@ -35,28 +35,15 @@ indicates that bins should be closed on the right (and open on the left) or
 vice versa (i.e. as in \code{\link[base]{cut.default}}). If a 
 single integer breaks value is provided, then the appropriate breakpoints 
 are determined based on the value of \code{breaks_mode}, and the value for 
-\code{right} is only utilized if \code{breaks_mode = 'spread'} - see below 
+\code{right} is not utilized if \code{breaks_mode = 'pretty'} - see below 
 for details.}
 
 \item{ordered_result}{Logical: should the result be an ordered factor?}
 
 \item{breaks_mode}{A parameter indicating how to determine the intervals 
 when breaks is specified as a scalar (note that this argument has no effect 
-if breaks is specified as a vector).
-\itemize{ 
-  \item 'default' will produce intervals which are the (integer) equivalent 
-  to those produced by cut.default i.e. the bins/groupings will be the 
-  same - but the labels will be of the form int-int/2-4 instead of 
-  (numeric, numeric]/(1.5,4.2].
-  \item 'spread' will result in intervals spread as evenly as possible 
-  over the exact range of \code{x}. If the intervals cannot all be equal, 
-  then \code{right} determines whether the rightmost (\code{TRUE}) or 
-  leftmost (\code{FALSE}) intervals are made slightly wider.
-  \item 'pretty' will generate rounded breakpoints for the intervals based 
-  on \code{\link[base]{pretty}}. Note that breaks here is treated as the 
-  'desired' number of intervals and is not guaranteed. Note also that the 
-  range of \code{x} can be exceeded slightly by the intervals in some 
-  cases.}}
+if breaks is specified as a vector). Can be 'default', 'spread' or 
+'pretty'. See 'Details' below.}
 
 \item{label_sep}{A single or short character string used to generate labels
 for the intervals e.g. the default value of "-" will result in labels like
@@ -76,10 +63,26 @@ to the interval they fall into.
 \details{
 In deviation from \code{cut.default}, \code{cut.integer} does not 
  have an argument \code{dig.lab}, but instead has two arguments that do not 
- exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}.
+ exist for \code{cut.default}: \code{breaks_mode} and \code{label_sep}. \cr
  Note that unlike \code{\link[base]{cut.default}}, here 
  \code{include.lowest} defaults to \code{TRUE}, since this is more intuitive 
- for the class \code{integer}.
+ for the class \code{integer}. \cr
+ If \code{breaks} is supplied as a scalar, the value of \code{breaks_mode} determines 
+ how the breaks are constructed:
+ \itemize{ 
+   \item 'default' will produce intervals which are the (integer) equivalent 
+   to those produced by \code{cut.default} i.e. the bins/groupings will be the 
+   same - but the labels will be of the form int-int/2-4 instead of 
+   (numeric, numeric]/(1.5,4.2].
+   \item 'spread' will result in intervals spread as evenly as possible 
+   over the exact range of \code{x}. If the intervals cannot all be equal, 
+   then \code{right} determines whether the rightmost (\code{TRUE}) or 
+   leftmost (\code{FALSE}) intervals are made slightly wider.
+   \item 'pretty' will generate rounded breakpoints for the intervals based 
+   on \code{\link[base]{pretty}}. Note that breaks here is treated as the 
+   'desired' number of intervals and is not guaranteed. Note also that the 
+   range of \code{x} can be exceeded slightly by the intervals in some 
+   cases.}
 }
 \examples{
  random <- sample(10)

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -44,6 +44,26 @@ default_cut8 <- cut(int_norep, breaks = 3,
 cut.default8 <- cut.default(int_norep, breaks = 3, 
                             right = FALSE, include.lowest = TRUE)
 
+default_cut9 <- cut(int_norep, breaks = 4, 
+                    right = TRUE, include.lowest = TRUE)
+cut.default9 <- cut.default(int_norep, breaks = 4, 
+                            right = TRUE, include.lowest = TRUE)
+
+default_cut10 <- cut(int_norep, breaks = 4, 
+                     right = TRUE, include.lowest = FALSE)
+cut.default10 <- cut.default(int_norep, breaks = 4, 
+                             right = TRUE, include.lowest = FALSE)
+
+default_cut11 <- cut(int_norep, breaks = 4, 
+                     right = FALSE, include.lowest = FALSE)
+cut.default11 <- cut.default(int_norep, breaks = 4, 
+                             right = FALSE, include.lowest = FALSE)
+
+default_cut12 <- cut(int_norep, breaks = 4, 
+                     right = FALSE, include.lowest = TRUE)
+cut.default12 <- cut.default(int_norep, breaks = 4, 
+                             right = FALSE, include.lowest = TRUE)
+
 test_that("default for cut.integer returns a factor", {
 
   expect_factor(default_cut1)
@@ -54,6 +74,10 @@ test_that("default for cut.integer returns a factor", {
   expect_factor(default_cut6)
   expect_factor(default_cut7)
   expect_factor(default_cut8)
+  expect_factor(default_cut9)
+  expect_factor(default_cut10)
+  expect_factor(default_cut11)
+  expect_factor(default_cut12)
     
 })
 
@@ -97,6 +121,26 @@ test_that("default for cut.integer results in same integer codes as cut.default"
   expect_equal(
     as.integer(default_cut8),
     as.integer(cut.default8)
+  )
+  
+  expect_equal(
+    as.integer(default_cut9),
+    as.integer(cut.default9)
+  )
+  
+  expect_equal(
+    as.integer(default_cut10),
+    as.integer(cut.default10)
+  )
+  
+  expect_equal(
+    as.integer(default_cut11),
+    as.integer(cut.default11)
+  )
+  
+  expect_equal(
+    as.integer(default_cut12),
+    as.integer(cut.default12)
   )
   
 })

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -1,8 +1,56 @@
+int_norep <- sample(10, replace = FALSE)
+int2_norep <- sample(15, replace = FALSE)
+int3_norep <- sample(99, replace = FALSE)
+
 context("integer_cut (default)")
 
-context("integer_cut (spread)")
+default_cut1 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = TRUE)
+cut.default1 <- cut.default(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = TRUE)
 
-int_norep <- sample(10, replace = FALSE)
+default_cut2 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = FALSE)
+cut.default2 <- cut.default(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = FALSE)
+
+default_cut3 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = FALSE)
+cut.default3 <- cut.default(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = FALSE)
+
+default_cut4 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = TRUE)
+cut.default4 <- cut.default(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = TRUE)
+
+test_that("default for cut.integer returns a factor", {
+
+  expect_factor(default_cut1)
+  expect_factor(default_cut2)
+  expect_factor(default_cut3)
+  expect_factor(default_cut4)
+    
+})
+
+test_that("default for cut.integer results in same integer codes as cut.default", {
+  
+  expect_equal(
+    as.integer(default_cut1),
+    as.integer(cut.default1)
+  )
+  
+  expect_equal(
+    as.integer(default_cut2),
+    as.integer(cut.default2)
+  )
+  
+  expect_equal(
+    as.integer(default_cut3),
+    as.integer(cut.default3)
+  )
+  
+  expect_equal(
+    as.integer(default_cut4),
+    as.integer(cut.default4)
+  )
+  
+})
+    
+
+context("integer_cut (spread)")
 
 case1 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, 
              include.lowest = FALSE, breaks_mode = "spread")
@@ -18,7 +66,7 @@ case6 <- cut(int_norep, breaks = 2, right = TRUE, breaks_mode = "spread")
 case7 <- cut(int_norep, breaks = 3, right = FALSE, breaks_mode = "spread")
 case8 <- cut(int_norep, breaks = 3, right = TRUE, breaks_mode = "spread")
 
-int2_norep <- sample(15, replace = FALSE)
+
 
 case9 <- cut(int2_norep, breaks = 3, right = FALSE, breaks_mode = "spread")
 case10 <- cut(int2_norep, breaks = 3, right = TRUE, breaks_mode = "spread")
@@ -27,7 +75,6 @@ case12 <- cut(int2_norep, breaks = 4, right = TRUE, breaks_mode = "spread")
 case13 <- cut(int2_norep, breaks = 5, right = FALSE, breaks_mode = "spread")
 case14 <- cut(int2_norep, breaks = 5, right = TRUE, breaks_mode = "spread")
 
-int3_norep <- sample(99, replace = FALSE)
 
 case15 <- cut(int3_norep, breaks = 3, right = FALSE, breaks_mode = "spread")
 case16 <- cut(int3_norep, breaks = 3, right = TRUE, breaks_mode = "spread")
@@ -221,3 +268,4 @@ test_that("cut.integer if breaks outside range(x)", {
 # cut(int_norep, breaks = c(1, 2, 3, 10), right = T, include.lowest = FALSE)
 
 context("integer_cut (pretty)")
+

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -24,12 +24,36 @@ default_cut4 <- cut(int_norep, breaks = c(1, 5, 10),
 cut.default4 <- cut.default(int_norep, breaks = c(1, 5, 10), 
                     right = FALSE, include.lowest = TRUE)
 
+default_cut5 <- cut(int_norep, breaks = 3, 
+                    right = TRUE, include.lowest = TRUE)
+cut.default5 <- cut.default(int_norep, breaks = 3, 
+                            right = TRUE, include.lowest = TRUE)
+
+default_cut6 <- cut(int_norep, breaks = 3, 
+                    right = TRUE, include.lowest = FALSE)
+cut.default6 <- cut.default(int_norep, breaks = 3, 
+                            right = TRUE, include.lowest = FALSE)
+
+default_cut7 <- cut(int_norep, breaks = 3, 
+                    right = FALSE, include.lowest = FALSE)
+cut.default7 <- cut.default(int_norep, breaks = 3, 
+                            right = FALSE, include.lowest = FALSE)
+
+default_cut8 <- cut(int_norep, breaks = 3, 
+                    right = FALSE, include.lowest = TRUE)
+cut.default8 <- cut.default(int_norep, breaks = 3, 
+                            right = FALSE, include.lowest = TRUE)
+
 test_that("default for cut.integer returns a factor", {
 
   expect_factor(default_cut1)
   expect_factor(default_cut2)
   expect_factor(default_cut3)
   expect_factor(default_cut4)
+  expect_factor(default_cut5)
+  expect_factor(default_cut6)
+  expect_factor(default_cut7)
+  expect_factor(default_cut8)
     
 })
 
@@ -53,6 +77,26 @@ test_that("default for cut.integer results in same integer codes as cut.default"
   expect_equal(
     as.integer(default_cut4),
     as.integer(cut.default4)
+  )
+  
+  expect_equal(
+    as.integer(default_cut5),
+    as.integer(cut.default5)
+  )
+  
+  expect_equal(
+    as.integer(default_cut6),
+    as.integer(cut.default6)
+  )
+  
+  expect_equal(
+    as.integer(default_cut7),
+    as.integer(cut.default7)
+  )
+  
+  expect_equal(
+    as.integer(default_cut8),
+    as.integer(cut.default8)
   )
   
 })

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -2,66 +2,74 @@ context("integer_cut")
 
 int_norep <- sample(10, replace = FALSE)
 
-case1 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = FALSE)
-case2 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = TRUE)
-case3 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = FALSE)
-case4 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = TRUE)
+case1 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, 
+             include.lowest = FALSE, breaks_mode = "spread")
+case2 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, 
+             include.lowest = TRUE, breaks_mode = "spread")
+case3 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, 
+             include.lowest = FALSE, breaks_mode = "spread")
+case4 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, 
+             include.lowest = TRUE, breaks_mode = "spread")
 
-case5 <- cut(int_norep, breaks = 2, right = FALSE)
-case6 <- cut(int_norep, breaks = 2, right = TRUE)
-case7 <- cut(int_norep, breaks = 3, right = FALSE)
-case8 <- cut(int_norep, breaks = 3, right = TRUE)
+case5 <- cut(int_norep, breaks = 2, right = FALSE, breaks_mode = "spread")
+case6 <- cut(int_norep, breaks = 2, right = TRUE, breaks_mode = "spread")
+case7 <- cut(int_norep, breaks = 3, right = FALSE, breaks_mode = "spread")
+case8 <- cut(int_norep, breaks = 3, right = TRUE, breaks_mode = "spread")
 
 int2_norep <- sample(15, replace = FALSE)
 
-case9 <- cut(int2_norep, breaks = 3, right = FALSE)
-case10 <- cut(int2_norep, breaks = 3, right = TRUE)
-case11 <- cut(int2_norep, breaks = 4, right = FALSE)
-case12 <- cut(int2_norep, breaks = 4, right = TRUE)
-case13 <- cut(int2_norep, breaks = 5, right = FALSE)
-case14 <- cut(int2_norep, breaks = 5, right = TRUE)
+case9 <- cut(int2_norep, breaks = 3, right = FALSE, breaks_mode = "spread")
+case10 <- cut(int2_norep, breaks = 3, right = TRUE, breaks_mode = "spread")
+case11 <- cut(int2_norep, breaks = 4, right = FALSE, breaks_mode = "spread")
+case12 <- cut(int2_norep, breaks = 4, right = TRUE, breaks_mode = "spread")
+case13 <- cut(int2_norep, breaks = 5, right = FALSE, breaks_mode = "spread")
+case14 <- cut(int2_norep, breaks = 5, right = TRUE, breaks_mode = "spread")
 
 int3_norep <- sample(99, replace = FALSE)
 
-case15 <- cut(int3_norep, breaks = 3, right = FALSE)
-case16 <- cut(int3_norep, breaks = 3, right = TRUE)
-case17 <- cut(int3_norep, breaks = 4, right = FALSE)
-case18 <- cut(int3_norep, breaks = 4, right = TRUE)
-case19 <- cut(int3_norep, breaks = 5, right = FALSE)
-case20 <- cut(int3_norep, breaks = 5, right = TRUE)
+case15 <- cut(int3_norep, breaks = 3, right = FALSE, breaks_mode = "spread")
+case16 <- cut(int3_norep, breaks = 3, right = TRUE, breaks_mode = "spread")
+case17 <- cut(int3_norep, breaks = 4, right = FALSE, breaks_mode = "spread")
+case18 <- cut(int3_norep, breaks = 4, right = TRUE, breaks_mode = "spread")
+case19 <- cut(int3_norep, breaks = 5, right = FALSE, breaks_mode = "spread")
+case20 <- cut(int3_norep, breaks = 5, right = TRUE, breaks_mode = "spread")
 
 # for extremely few values in x 
-case21 <- cut(1L, breaks = c(0, 1, 9), include.lowest = TRUE)
+case21 <- cut(1L, breaks = c(0, 1, 9), include.lowest = TRUE, 
+              breaks_mode = "spread")
 
 # non-default labels
-case22 <- cut(sample(10), breaks = 3, labels = letters[1:3])
-case23 <- cut(sample(10), breaks = 3, labels = FALSE)
+case22 <- cut(sample(10), breaks = 3, labels = letters[1:3], breaks_mode = "spread")
+case23 <- cut(sample(10), breaks = 3, labels = FALSE, breaks_mode = "spread")
 
 # for extremely few values in breaks
 ## breaks as scalar
 
-case24 <- cut(sample(10), breaks = 1, labels = FALSE) # desired outcome although 
-# not in line with cut.defalt
-case25 <- cut(sample(10), breaks = 1, labels = NULL)
-case26 <- cut(sample(10), breaks = 1, labels = "lion") 
+# desired outcome although not in line with cut.defalt
+case24 <- cut(sample(10), breaks = 1, labels = FALSE, breaks_mode = "spread") 
+case25 <- cut(sample(10), breaks = 1, labels = NULL, breaks_mode = "spread")
+case26 <- cut(sample(10), breaks = 1, labels = "lion", breaks_mode = "spread") 
 
 # breaks as vector
-case27 <- cut(sample(10), breaks = c(1, 10), labels = FALSE) 
-case28 <- cut(sample(10), breaks = c(1, 10), labels = NULL)
-case29 <- cut(sample(10), breaks = c(1, 10), labels = "lion")
+case27 <- cut(sample(10), breaks = c(1, 10), labels = FALSE, 
+              breaks_mode = "spread") 
+case28 <- cut(sample(10), breaks = c(1, 10), labels = NULL, 
+              breaks_mode = "spread")
+case29 <- cut(sample(10), breaks = c(1, 10), labels = "lion", 
+              breaks_mode = "spread")
 
 # not desired outcome although it should be without 
 # cut.default(sample(10), breaks = 1, labels = FALSE)
 
 # when breaks are of class integer
-case30 <- cut(sample(10), breaks = c(1L, 3L, 10L))
+case30 <- cut(sample(10), breaks = c(1L, 3L, 10L), breaks_mode = "spread")
 
 # when breaks need to be rounded
-case31 <- cut(sample(10), breaks = c(1, 2.6, 5.1, 10))
+case31 <- cut(sample(10), breaks = c(1, 2.6, 5.1, 10), breaks_mode = "spread")
 
 
 ## where binwidth is 1
-case32a <- cut(1:10, breaks = 9, right = FALSE)
+case32a <- cut(1:10, breaks = 9, right = FALSE, breaks_mode = "spread")
 
 
 test_that(paste("cut.integer returns same as cut.default but with better", 
@@ -187,16 +195,16 @@ test_that("binwidth 1", {
   expect_equal(levels(case32a),
                c("1-2", "3", "4", "5", "6", "7", "8", "9", "10"))
   
-  # the waring that goes with it for right = FALSE
+  # the warning that goes with it for right = FALSE
   ## x is even
-  expect_warning(cut(1:10, breaks = 9, right = FALSE), 
+  expect_warning(cut(1:10, breaks = 9, right = FALSE, breaks_mode = "spread"), 
                 "are: 3, 4, 5, 6, 7, 8, 9, 10")
   ## x is odd
-  expect_warning(cut(1:11, breaks = 9, right = FALSE), 
+  expect_warning(cut(1:11, breaks = 9, right = FALSE, breaks_mode = "spread"), 
                  "are: 5, 6, 7, 8, 9, 10, 11")
   # the waring that goes with it for right = TRUE
   ## breaks are even
-  expect_warning(cut(1:10, breaks = 8, right = TRUE), 
+  expect_warning(cut(1:10, breaks = 8, right = TRUE, breaks_mode = "spread"), 
                  "are: 1, 2, 3, 4, 5, 6")
 })
 

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -1,4 +1,6 @@
-context("integer_cut")
+context("integer_cut (default)")
+
+context("integer_cut (spread)")
 
 int_norep <- sample(10, replace = FALSE)
 
@@ -217,3 +219,5 @@ test_that("cut.integer if breaks outside range(x)", {
 # what happens in binwidth 1 if none is this width (line 99)
 # not optimal:
 # cut(int_norep, breaks = c(1, 2, 3, 10), right = T, include.lowest = FALSE)
+
+context("integer_cut (pretty)")

--- a/tests/testthat/test-integer_cut.R
+++ b/tests/testthat/test-integer_cut.R
@@ -4,17 +4,25 @@ int3_norep <- sample(99, replace = FALSE)
 
 context("integer_cut (default)")
 
-default_cut1 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = TRUE)
-cut.default1 <- cut.default(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = TRUE)
+default_cut1 <- cut(int_norep, breaks = c(1, 5, 10), 
+                    right = TRUE, include.lowest = TRUE)
+cut.default1 <- cut.default(int_norep, breaks = c(1, 5, 10), 
+                    right = TRUE, include.lowest = TRUE)
 
-default_cut2 <- cut(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = FALSE)
-cut.default2 <- cut.default(int_norep, breaks = c(1, 5, 10), right = TRUE, include.lowest = FALSE)
+default_cut2 <- cut(int_norep, breaks = c(1, 5, 10), 
+                    right = TRUE, include.lowest = FALSE)
+cut.default2 <- cut.default(int_norep, breaks = c(1, 5, 10), 
+                    right = TRUE, include.lowest = FALSE)
 
-default_cut3 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = FALSE)
-cut.default3 <- cut.default(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = FALSE)
+default_cut3 <- cut(int_norep, breaks = c(1, 5, 10), 
+                    right = FALSE, include.lowest = FALSE)
+cut.default3 <- cut.default(int_norep, breaks = c(1, 5, 10), 
+                    right = FALSE, include.lowest = FALSE)
 
-default_cut4 <- cut(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = TRUE)
-cut.default4 <- cut.default(int_norep, breaks = c(1, 5, 10), right = FALSE, include.lowest = TRUE)
+default_cut4 <- cut(int_norep, breaks = c(1, 5, 10), 
+                    right = FALSE, include.lowest = TRUE)
+cut.default4 <- cut.default(int_norep, breaks = c(1, 5, 10), 
+                    right = FALSE, include.lowest = TRUE)
 
 test_that("default for cut.integer returns a factor", {
 
@@ -269,3 +277,20 @@ test_that("cut.integer if breaks outside range(x)", {
 
 context("integer_cut (pretty)")
 
+pretty_cut1 <- cut(int_norep, breaks = 3, breaks_mode = "pretty")
+pretty_cut2 <- cut(int2_norep, breaks = 5, breaks_mode = "pretty")
+pretty_cut3 <- cut(int3_norep, breaks = 10, breaks_mode = "pretty")
+pretty_cut4 <- cut(int_norep, breaks = 6, breaks_mode = "pretty")
+pretty_cut5 <- cut(int2_norep, breaks = 10, breaks_mode = "pretty")
+pretty_cut6 <- cut(int3_norep, breaks = 20, breaks_mode = "pretty")
+
+test_that("pretty for cut.integer returns a factor", {
+  
+  expect_factor(pretty_cut1)
+  expect_factor(pretty_cut2)
+  expect_factor(pretty_cut3)
+  expect_factor(pretty_cut4)
+  expect_factor(pretty_cut5)
+  expect_factor(pretty_cut6)
+  
+})


### PR DESCRIPTION
Update breaks_mode with new 'default' method to emulate cut.default and rename existing method to 'spread', update documentation to reflect these functional changes and further clarify behavior, update testing of cut.integer due based on the new modes.
